### PR TITLE
fix(date-picker): guard hover styles with any-hover

### DIFF
--- a/css/vendor/carbon-components/scss/components/date-picker/_date-picker.scss
+++ b/css/vendor/carbon-components/scss/components/date-picker/_date-picker.scss
@@ -108,8 +108,10 @@
       color: $text-disabled;
     }
 
-    &:disabled:hover {
-      border-bottom: 1px solid transparent;
+    @media (any-hover: hover) {
+      &:disabled:hover {
+        border-bottom: 1px solid transparent;
+      }
     }
 
     &::placeholder {

--- a/css/vendor/carbon-components/scss/components/date-picker/_flatpickr.scss
+++ b/css/vendor/carbon-components/scss/components/date-picker/_flatpickr.scss
@@ -189,8 +189,10 @@
     fill: $icon-01;
     user-select: none;
 
-    &:hover {
-      background-color: $hover-ui;
+    @media (any-hover: hover) {
+      &:hover {
+        background-color: $hover-ui;
+      }
     }
   }
 
@@ -200,9 +202,11 @@
     fill: $ui-05;
   }
 
-  .flatpickr-next-month.disabled:hover svg,
-  .flatpickr-prev-month.disabled:hover svg {
-    fill: $ui-05;
+  @media (any-hover: hover) {
+    .flatpickr-next-month.disabled:hover svg,
+    .flatpickr-prev-month.disabled:hover svg {
+      fill: $ui-05;
+    }
   }
 
   .flatpickr-current-month {
@@ -219,8 +223,10 @@
     margin-right: $carbon--spacing-02;
     margin-left: $carbon--spacing-02;
 
-    &:hover {
-      background-color: $hover-ui;
+    @media (any-hover: hover) {
+      &:hover {
+        background-color: $hover-ui;
+      }
     }
   }
 
@@ -228,8 +234,10 @@
     position: relative;
     width: to-rem(60px);
 
-    &:hover {
-      background-color: $hover-ui;
+    @media (any-hover: hover) {
+      &:hover {
+        background-color: $hover-ui;
+      }
     }
   }
 
@@ -259,11 +267,18 @@
       @include focus-outline('border');
     }
 
-    &[disabled],
-    &[disabled]:hover {
+    &[disabled] {
       color: $disabled-02;
       background-color: $ui-01;
       pointer-events: none;
+    }
+
+    @media (any-hover: hover) {
+      &[disabled]:hover {
+        color: $disabled-02;
+        background-color: $ui-01;
+        pointer-events: none;
+      }
     }
   }
 
@@ -305,9 +320,11 @@
       content: '';
     }
 
-    &:hover::after {
-      border-top-color: $interactive-01;
-      border-bottom-color: $interactive-01;
+    @media (any-hover: hover) {
+      &:hover::after {
+        border-top-color: $interactive-01;
+        border-bottom-color: $interactive-01;
+      }
     }
 
     &:active::after {
@@ -324,14 +341,16 @@
     border-top-color: $disabled-02;
   }
 
-  .numInputWrapper:hover .arrowUp,
-  .numInputWrapper:hover .arrowDown {
-    opacity: 1;
-  }
+  @media (any-hover: hover) {
+    .numInputWrapper:hover .arrowUp,
+    .numInputWrapper:hover .arrowDown {
+      opacity: 1;
+    }
 
-  .numInputWrapper:hover .numInput[disabled] ~ .arrowUp,
-  .numInputWrapper:hover .numInput[disabled] ~ .arrowDown {
-    opacity: 0;
+    .numInputWrapper:hover .numInput[disabled] ~ .arrowUp,
+    .numInputWrapper:hover .numInput[disabled] ~ .arrowDown {
+      opacity: 0;
+    }
   }
 
   .flatpickr-weekdays {
@@ -395,8 +414,10 @@
     cursor: pointer;
     transition: all $duration--fast-01 motion(standard, productive);
 
-    &:hover {
-      background: $hover-ui;
+    @media (any-hover: hover) {
+      &:hover {
+        background: $hover-ui;
+      }
     }
 
     &:focus {
@@ -469,11 +490,13 @@
     background: $ui-01;
   }
 
-  .flatpickr-day.endRange:hover {
-    @include focus-outline('outline');
+  @media (any-hover: hover) {
+    .flatpickr-day.endRange:hover {
+      @include focus-outline('outline');
 
-    color: $text-01;
-    background: $ui-01;
+      color: $text-01;
+      background: $ui-01;
+    }
   }
 
   .flatpickr-day.endRange.inRange.selected {
@@ -485,8 +508,10 @@
     color: $disabled-02;
     cursor: not-allowed;
 
-    &:hover {
-      background-color: transparent;
+    @media (any-hover: hover) {
+      &:hover {
+        background-color: transparent;
+      }
     }
   }
 

--- a/css/vendor/carbon-components/scss/components/file-uploader/_file-uploader.scss
+++ b/css/vendor/carbon-components/scss/components/file-uploader/_file-uploader.scss
@@ -49,12 +49,10 @@
     outline-offset: -2px;
     transition: $duration--fast-02 motion(standard, productive);
 
-    &:focus,
-    &:hover {
+    &:focus {
       outline: 2px solid $interactive-03;
     }
 
-    &:hover,
     &:focus,
     &:active,
     &:active:visited {
@@ -64,6 +62,13 @@
     &:active {
       color: $text-01;
     }
+
+    @media (any-hover: hover) {
+      &:hover {
+        outline: 2px solid $interactive-03;
+        text-decoration: underline;
+      }
+    }
   }
 
   .#{$prefix}--file-browse-btn--disabled {
@@ -71,11 +76,18 @@
     cursor: no-drop;
     text-decoration: none;
 
-    &:hover,
     &:focus {
       color: $disabled-02;
       outline: none;
       text-decoration: none;
+    }
+
+    @media (any-hover: hover) {
+      &:hover {
+        color: $disabled-02;
+        outline: none;
+        text-decoration: none;
+      }
     }
   }
 

--- a/css/vendor/carbon-components/scss/components/menu/_menu.scss
+++ b/css/vendor/carbon-components/scss/components/menu/_menu.scss
@@ -52,15 +52,24 @@
     }
   }
 
-  .#{$prefix}--menu-option--active,
-  .#{$prefix}--menu-option:hover {
+  .#{$prefix}--menu-option--active {
     background-color: $layer-hover;
   }
 
-  .#{$prefix}--menu-option--danger:hover,
   .#{$prefix}--menu-option--danger:focus {
     background-color: $button-danger-primary;
     color: $text-on-color;
+  }
+
+  @media (any-hover: hover) {
+    .#{$prefix}--menu-option:hover {
+      background-color: $layer-hover;
+    }
+
+    .#{$prefix}--menu-option--danger:hover {
+      background-color: $button-danger-primary;
+      color: $text-on-color;
+    }
   }
 
   .#{$prefix}--menu-option > .#{$prefix}--menu {

--- a/css/vendor/carbon-components/scss/components/overflow-menu/_overflow-menu.scss
+++ b/css/vendor/carbon-components/scss/components/overflow-menu/_overflow-menu.scss
@@ -37,8 +37,10 @@
       @include focus-outline('outline');
     }
 
-    &:hover {
-      background-color: $hover-ui;
+    @media (any-hover: hover) {
+      &:hover {
+        background-color: $hover-ui;
+      }
     }
   }
 
@@ -99,8 +101,10 @@
     }
   }
 
-  .#{$prefix}--overflow-menu.#{$prefix}--overflow-menu--open:hover {
-    background-color: $field-01;
+  @media (any-hover: hover) {
+    .#{$prefix}--overflow-menu.#{$prefix}--overflow-menu--open:hover {
+      background-color: $field-01;
+    }
   }
 
   .#{$prefix}--overflow-menu-options--light {
@@ -111,8 +115,10 @@
     }
   }
 
-  .#{$prefix}--overflow-menu.#{$prefix}--overflow-menu--light.#{$prefix}--overflow-menu--open:hover {
-    background-color: $field-02;
+  @media (any-hover: hover) {
+    .#{$prefix}--overflow-menu.#{$prefix}--overflow-menu--light.#{$prefix}--overflow-menu--open:hover {
+      background-color: $field-02;
+    }
   }
 
   .#{$prefix}--overflow-menu-options[data-floating-menu-direction='bottom']::after {
@@ -247,8 +253,10 @@
       background-color $duration--fast-02 motion(entrance, productive),
       color $duration--fast-02 motion(entrance, productive);
 
-    &:hover {
-      color: $text-01;
+    @media (any-hover: hover) {
+      &:hover {
+        color: $text-01;
+      }
     }
 
     &:focus {
@@ -264,8 +272,10 @@
     fill: $icon-02;
   }
 
-  .#{$prefix}--overflow-menu-options__btn:hover svg {
-    fill: $icon-01;
+  @media (any-hover: hover) {
+    .#{$prefix}--overflow-menu-options__btn:hover svg {
+      fill: $icon-01;
+    }
   }
 
   .#{$prefix}--overflow-menu-options__option-content {
@@ -274,12 +284,12 @@
     white-space: nowrap;
   }
 
-  .#{$prefix}--overflow-menu-options__option:hover {
-    background-color: $hover-ui;
+  @media (any-hover: hover) {
+    .#{$prefix}--overflow-menu-options__option:hover {
+      background-color: $hover-ui;
+    }
   }
 
-  .#{$prefix}--overflow-menu-options__option--danger
-    .#{$prefix}--overflow-menu-options__btn:hover,
   .#{$prefix}--overflow-menu-options__option--danger
     .#{$prefix}--overflow-menu-options__btn:focus {
     background-color: $danger-01;
@@ -290,9 +300,16 @@
     }
   }
 
-  .#{$prefix}--overflow-menu-options__option--disabled:hover {
-    background-color: $ui-01;
-    cursor: not-allowed;
+  @media (any-hover: hover) {
+    .#{$prefix}--overflow-menu-options__option--danger
+      .#{$prefix}--overflow-menu-options__btn:hover {
+      background-color: $danger-01;
+      color: $text-04;
+
+      svg {
+        fill: currentColor;
+      }
+    }
   }
 
   .#{$prefix}--overflow-menu-options__option--disabled
@@ -300,12 +317,27 @@
     color: $disabled-02;
     pointer-events: none;
 
-    &:hover,
     &:active,
     &:focus {
       @include focus-outline('reset');
 
       background-color: $ui-01;
+    }
+  }
+
+  @media (any-hover: hover) {
+    .#{$prefix}--overflow-menu-options__option--disabled:hover {
+      background-color: $ui-01;
+      cursor: not-allowed;
+    }
+
+    .#{$prefix}--overflow-menu-options__option--disabled
+      .#{$prefix}--overflow-menu-options__btn {
+      &:hover {
+        @include focus-outline('reset');
+
+        background-color: $ui-01;
+      }
     }
   }
 

--- a/css/vendor/carbon-components/scss/components/pagination-nav/_pagination-nav.scss
+++ b/css/vendor/carbon-components/scss/components/pagination-nav/_pagination-nav.scss
@@ -116,9 +116,11 @@
       color $duration--fast-02 motion(standard, productive);
     user-select: none;
 
-    &:hover {
-      background-color: $background-color-hover;
-      color: $text-color;
+    @media (any-hover: hover) {
+      &:hover {
+        background-color: $background-color-hover;
+        color: $text-color;
+      }
     }
 
     &:focus {

--- a/css/vendor/carbon-components/scss/components/slider/_slider.scss
+++ b/css/vendor/carbon-components/scss/components/slider/_slider.scss
@@ -89,9 +89,11 @@
       background $duration--fast-02 motion(standard, productive),
       box-shadow $duration--fast-02 motion(standard, productive);
 
-    &:hover {
-      // 20px / 14px = 1.4286
-      transform: translate(-50%, -50%) scale(1.4286);
+    @media (any-hover: hover) {
+      &:hover {
+        // 20px / 14px = 1.4286
+        transform: translate(-50%, -50%) scale(1.4286);
+      }
     }
 
     &:focus {
@@ -141,9 +143,11 @@
   .#{$prefix}--slider--disabled .#{$prefix}--slider__thumb {
     background-color: $ui-03;
 
-    &:hover {
-      cursor: not-allowed;
-      transform: translate(-50%, -50%);
+    @media (any-hover: hover) {
+      &:hover {
+        cursor: not-allowed;
+        transform: translate(-50%, -50%);
+      }
     }
 
     &:focus {
@@ -178,10 +182,16 @@
     transition: none;
 
     &:active,
-    &:focus,
-    &:hover {
+    &:focus {
       color: $disabled-02;
       outline: none;
+    }
+
+    @media (any-hover: hover) {
+      &:hover {
+        color: $disabled-02;
+        outline: none;
+      }
     }
   }
 

--- a/css/vendor/carbon-components/scss/components/structured-list/_structured-list.scss
+++ b/css/vendor/carbon-components/scss/components/structured-list/_structured-list.scss
@@ -79,11 +79,13 @@
     transition: background-color $duration--fast-02 motion(standard, productive);
   }
 
-  .#{$prefix}--structured-list--selection
-    .#{$prefix}--structured-list-row:hover:not(.#{$prefix}--structured-list-row--header-row):not(.#{$prefix}--structured-list-row--selected) {
-    border-bottom: 1px solid $hover-row;
-    background-color: $hover-row;
-    cursor: pointer;
+  @media (any-hover: hover) {
+    .#{$prefix}--structured-list--selection
+      .#{$prefix}--structured-list-row:hover:not(.#{$prefix}--structured-list-row--header-row):not(.#{$prefix}--structured-list-row--selected) {
+      border-bottom: 1px solid $hover-row;
+      background-color: $hover-row;
+      cursor: pointer;
+    }
   }
 
   .#{$prefix}--structured-list-row.#{$prefix}--structured-list-row--header-row {
@@ -96,19 +98,21 @@
       @include focus-outline('outline');
     }
   }
-  .#{$prefix}--structured-list--selection
-    .#{$prefix}--structured-list-row:hover:not(.#{$prefix}--structured-list-row--header-row)
-    > .#{$prefix}--structured-list-td {
-    color: $text-01;
-  }
+  @media (any-hover: hover) {
+    .#{$prefix}--structured-list--selection
+      .#{$prefix}--structured-list-row:hover:not(.#{$prefix}--structured-list-row--header-row)
+      > .#{$prefix}--structured-list-td {
+      color: $text-01;
+    }
 
-  .#{$prefix}--structured-list--selection
-    .#{$prefix}--structured-list-row:hover:not(.#{$prefix}--structured-list-row--header-row)
-    > .#{$prefix}--structured-list-td {
-    @if feature-flag-enabled('enable-v11-release') {
-      border-top: 1px solid $border-subtle;
-    } @else {
-      border-top: 1px solid $ui-01;
+    .#{$prefix}--structured-list--selection
+      .#{$prefix}--structured-list-row:hover:not(.#{$prefix}--structured-list-row--header-row)
+      > .#{$prefix}--structured-list-td {
+      @if feature-flag-enabled('enable-v11-release') {
+        border-top: 1px solid $border-subtle;
+      } @else {
+        border-top: 1px solid $ui-01;
+      }
     }
   }
 
@@ -271,10 +275,12 @@
   // where the wrapper sits. Giving the wrapper the identical
   // conditional border keeps every column's top edge resolving the same
   // way, hover or not.
-  .#{$prefix}--structured-list--selection
-    .#{$prefix}--structured-list-row:hover:not(.#{$prefix}--structured-list-row--header-row)
-    > .#{$prefix}--structured-list-input-wrapper {
-    border-top: 1px solid $ui-01;
+  @media (any-hover: hover) {
+    .#{$prefix}--structured-list--selection
+      .#{$prefix}--structured-list-row:hover:not(.#{$prefix}--structured-list-row--header-row)
+      > .#{$prefix}--structured-list-input-wrapper {
+      border-top: 1px solid $ui-01;
+    }
   }
 
   // Carbon's base CSS fills the selection icon via

--- a/css/vendor/carbon-components/scss/components/tag/_mixins.scss
+++ b/css/vendor/carbon-components/scss/components/tag/_mixins.scss
@@ -13,8 +13,10 @@
 
   &.#{$prefix}--tag--interactive,
   .#{$prefix}--tag__close-icon {
-    &:hover {
-      background-color: $filter-hover-color;
+    @media (any-hover: hover) {
+      &:hover {
+        background-color: $filter-hover-color;
+      }
     }
   }
 }

--- a/css/vendor/carbon-components/scss/components/tag/_tag.scss
+++ b/css/vendor/carbon-components/scss/components/tag/_tag.scss
@@ -141,8 +141,10 @@
   .#{$prefix}--tag--interactive.#{$prefix}--tag--disabled {
     @include tag-theme($disabled-01, $disabled-02);
 
-    &:hover {
-      cursor: not-allowed;
+    @media (any-hover: hover) {
+      &:hover {
+        cursor: not-allowed;
+      }
     }
   }
 
@@ -158,8 +160,10 @@
     outline: none;
   }
 
-  .#{$prefix}--tag--interactive:hover {
-    cursor: pointer;
+  @media (any-hover: hover) {
+    .#{$prefix}--tag--interactive:hover {
+      cursor: pointer;
+    }
   }
 
   .#{$prefix}--tag--filter {
@@ -168,8 +172,10 @@
     padding-bottom: 0;
     cursor: pointer;
 
-    &:hover {
-      outline: none;
+    @media (any-hover: hover) {
+      &:hover {
+        outline: none;
+      }
     }
   }
 
@@ -229,9 +235,11 @@
     box-shadow: inset 0 0 0 1px $inverse-focus-ui;
   }
 
-  .#{$prefix}--tag--filter.#{$prefix}--tag--disabled
-    .#{$prefix}--tag__close-icon:hover {
-    background-color: transparent;
+  @media (any-hover: hover) {
+    .#{$prefix}--tag--filter.#{$prefix}--tag--disabled
+      .#{$prefix}--tag__close-icon:hover {
+      background-color: transparent;
+    }
   }
 
   .#{$prefix}--tag--filter.#{$prefix}--tag--disabled svg {

--- a/css/vendor/carbon-components/scss/components/text-input/_text-input.scss
+++ b/css/vendor/carbon-components/scss/components/text-input/_text-input.scss
@@ -142,11 +142,16 @@
     @include focus-outline('outline');
   }
 
-  .#{$prefix}--btn.#{$prefix}--text-input--password__visibility__toggle.#{$prefix}--tooltip__trigger:hover
-    svg,
   .#{$prefix}--btn.#{$prefix}--text-input--password__visibility__toggle.#{$prefix}--tooltip__trigger:focus
     svg {
     fill: $icon-primary;
+  }
+
+  @media (any-hover: hover) {
+    .#{$prefix}--btn.#{$prefix}--text-input--password__visibility__toggle.#{$prefix}--tooltip__trigger:hover
+      svg {
+      fill: $icon-primary;
+    }
   }
 
   .#{$prefix}--text-input--invalid,
@@ -180,8 +185,10 @@
     cursor: not-allowed;
     fill: $disabled-02;
 
-    &:hover {
-      fill: $disabled-02;
+    @media (any-hover: hover) {
+      &:hover {
+        fill: $disabled-02;
+      }
     }
   }
 
@@ -349,10 +356,16 @@
   // Windows HCM fix
   .#{$prefix}--text-input--password__visibility,
     // TODO: remove selector above
-  .#{$prefix}--btn.#{$prefix}--btn--icon-only.#{$prefix}--text-input--password__visibility__toggle.#{$prefix}--tooltip__trigger svg,
-    .#{$prefix}--btn.#{$prefix}--btn--icon-only.#{$prefix}--text-input--password__visibility__toggle.#{$prefix}--tooltip__trigger:hover
-    svg {
+  .#{$prefix}--btn.#{$prefix}--btn--icon-only.#{$prefix}--text-input--password__visibility__toggle.#{$prefix}--tooltip__trigger svg {
     @include high-contrast-mode('icon-fill');
+  }
+
+  // Windows HCM fix
+  @media (any-hover: hover) {
+    .#{$prefix}--btn.#{$prefix}--btn--icon-only.#{$prefix}--text-input--password__visibility__toggle.#{$prefix}--tooltip__trigger:hover
+      svg {
+      @include high-contrast-mode('icon-fill');
+    }
   }
 }
 

--- a/css/vendor/carbon-components/scss/components/treeview/_treeview.scss
+++ b/css/vendor/carbon-components/scss/components/treeview/_treeview.scss
@@ -36,30 +36,42 @@
       outline: none;
     }
 
-    .#{$prefix}--tree-node--disabled,
-    .#{$prefix}--tree-node--disabled .#{$prefix}--tree-node__label:hover,
-    .#{$prefix}--tree-node--disabled
-      .#{$prefix}--tree-node__label:hover
-      .#{$prefix}--tree-node__label__details {
+    .#{$prefix}--tree-node--disabled {
       background-color: $disabled-01;
       color: $disabled-02;
     }
 
     .#{$prefix}--tree-node--disabled .#{$prefix}--tree-parent-node__toggle-icon,
-    .#{$prefix}--tree-node--disabled .#{$prefix}--tree-node__icon,
-    .#{$prefix}--tree-node--disabled
-      .#{$prefix}--tree-node__label:hover
-      .#{$prefix}--tree-parent-node__toggle-icon,
-    .#{$prefix}--tree-node--disabled
-      .#{$prefix}--tree-node__label:hover
-      .#{$prefix}--tree-node__icon {
+    .#{$prefix}--tree-node--disabled .#{$prefix}--tree-node__icon {
       fill: $disabled-02;
     }
 
-    .#{$prefix}--tree-node--disabled,
-    .#{$prefix}--tree-node--disabled
-      .#{$prefix}--tree-parent-node__toggle-icon:hover {
+    .#{$prefix}--tree-node--disabled {
       cursor: not-allowed;
+    }
+
+    @media (any-hover: hover) {
+      .#{$prefix}--tree-node--disabled .#{$prefix}--tree-node__label:hover,
+      .#{$prefix}--tree-node--disabled
+        .#{$prefix}--tree-node__label:hover
+        .#{$prefix}--tree-node__label__details {
+        background-color: $disabled-01;
+        color: $disabled-02;
+      }
+
+      .#{$prefix}--tree-node--disabled
+        .#{$prefix}--tree-node__label:hover
+        .#{$prefix}--tree-parent-node__toggle-icon,
+      .#{$prefix}--tree-node--disabled
+        .#{$prefix}--tree-node__label:hover
+        .#{$prefix}--tree-node__icon {
+        fill: $disabled-02;
+      }
+
+      .#{$prefix}--tree-node--disabled
+        .#{$prefix}--tree-parent-node__toggle-icon:hover {
+        cursor: not-allowed;
+      }
     }
 
     .#{$prefix}--tree-node__label {
@@ -68,20 +80,24 @@
       flex: 1;
       align-items: center;
 
-      &:hover {
-        background-color: $hover-ui;
-        color: $text-01;
+      @media (any-hover: hover) {
+        &:hover {
+          background-color: $hover-ui;
+          color: $text-01;
+        }
       }
     }
 
-    .#{$prefix}--tree-node__label:hover .#{$prefix}--tree-node__label__details {
-      color: $text-01;
-    }
+    @media (any-hover: hover) {
+      .#{$prefix}--tree-node__label:hover .#{$prefix}--tree-node__label__details {
+        color: $text-01;
+      }
 
-    .#{$prefix}--tree-node__label:hover
-      .#{$prefix}--tree-parent-node__toggle-icon,
-    .#{$prefix}--tree-node__label:hover .#{$prefix}--tree-node__icon {
-      fill: $icon-01;
+      .#{$prefix}--tree-node__label:hover
+        .#{$prefix}--tree-parent-node__toggle-icon,
+      .#{$prefix}--tree-node__label:hover .#{$prefix}--tree-node__icon {
+        fill: $icon-01;
+      }
     }
 
     .#{$prefix}--tree-leaf-node {
@@ -107,8 +123,10 @@
       border: 0;
       margin-right: $spacing-03;
 
-      &:hover {
-        cursor: pointer;
+      @media (any-hover: hover) {
+        &:hover {
+          cursor: pointer;
+        }
       }
 
       &:focus {
@@ -136,8 +154,10 @@
       background-color: $selected-ui;
       color: $text-01;
 
-      &:hover {
-        background-color: $hover-selected-ui;
+      @media (any-hover: hover) {
+        &:hover {
+          background-color: $hover-selected-ui;
+        }
       }
     }
 

--- a/css/vendor/carbon-components/scss/components/ui-shell/_side-nav.scss
+++ b/css/vendor/carbon-components/scss/components/ui-shell/_side-nav.scss
@@ -46,7 +46,6 @@
     visibility: hidden;
   }
 
-  .#{$prefix}--side-nav:hover &,
   .#{$prefix}--side-nav--expanded & {
     @if $visibility == true {
       visibility: inherit;
@@ -55,6 +54,18 @@
       opacity: 1;
     }
     @content;
+  }
+
+  @media (any-hover: hover) {
+    .#{$prefix}--side-nav:hover & {
+      @if $visibility == true {
+        visibility: inherit;
+      }
+      @if $opacity == true {
+        opacity: 1;
+      }
+      @content;
+    }
   }
 }
 
@@ -93,9 +104,14 @@
     width: mini-units(6);
   }
 
-  .#{$prefix}--side-nav.#{$prefix}--side-nav--rail:not(.#{$prefix}--side-nav--fixed):hover,
   .#{$prefix}--side-nav--expanded {
     width: mini-units(32);
+  }
+
+  @media (any-hover: hover) {
+    .#{$prefix}--side-nav.#{$prefix}--side-nav--rail:not(.#{$prefix}--side-nav--fixed):hover {
+      width: mini-units(32);
+    }
   }
 
   .#{$prefix}--side-nav__overlay {
@@ -180,29 +196,31 @@
     height: auto;
   }
 
-  .#{$prefix}--side-nav__item:not(.#{$prefix}--side-nav__item--active):hover
+  @media (any-hover: hover) {
+    .#{$prefix}--side-nav__item:not(.#{$prefix}--side-nav__item--active):hover
+      .#{$prefix}--side-nav__item:not(.#{$prefix}--side-nav__item--active)
+      > .#{$prefix}--side-nav__submenu:hover,
     .#{$prefix}--side-nav__item:not(.#{$prefix}--side-nav__item--active)
-    > .#{$prefix}--side-nav__submenu:hover,
-  .#{$prefix}--side-nav__item:not(.#{$prefix}--side-nav__item--active)
-    > .#{$prefix}--side-nav__link:hover,
-  .#{$prefix}--side-nav__menu
-    a.#{$prefix}--side-nav__link:not(.#{$prefix}--side-nav__link--current):not([aria-current='page']):hover,
-  .#{$prefix}--side-nav a.#{$prefix}--header__menu-item:hover,
-  .#{$prefix}--side-nav
-    .#{$prefix}--header__menu-title[aria-expanded='true']:hover {
-    // TODO: sync color
-    background-color: $shell-side-nav-bg-04;
-    color: $ibm-color__gray-100;
-  }
+      > .#{$prefix}--side-nav__link:hover,
+    .#{$prefix}--side-nav__menu
+      a.#{$prefix}--side-nav__link:not(.#{$prefix}--side-nav__link--current):not([aria-current='page']):hover,
+    .#{$prefix}--side-nav a.#{$prefix}--header__menu-item:hover,
+    .#{$prefix}--side-nav
+      .#{$prefix}--header__menu-title[aria-expanded='true']:hover {
+      // TODO: sync color
+      background-color: $shell-side-nav-bg-04;
+      color: $ibm-color__gray-100;
+    }
 
-  .#{$prefix}--side-nav__item:not(.#{$prefix}--side-nav__item--active)
-    > .#{$prefix}--side-nav__link:hover
-    > span,
-  .#{$prefix}--side-nav__item:not(.#{$prefix}--side-nav__item--active)
-    .#{$prefix}--side-nav__menu-item
-    > .#{$prefix}--side-nav__link:hover
-    > span {
-    color: $ibm-color__gray-100;
+    .#{$prefix}--side-nav__item:not(.#{$prefix}--side-nav__item--active)
+      > .#{$prefix}--side-nav__link:hover
+      > span,
+    .#{$prefix}--side-nav__item:not(.#{$prefix}--side-nav__item--active)
+      .#{$prefix}--side-nav__menu-item
+      > .#{$prefix}--side-nav__link:hover
+      > span {
+      color: $ibm-color__gray-100;
+    }
   }
 
   .#{$prefix}--side-nav__item--large {
@@ -231,9 +249,11 @@
     user-select: none;
   }
 
-  .#{$prefix}--side-nav__submenu:hover {
-    background-color: $shell-side-nav-bg-04;
-    color: $ibm-color__gray-100;
+  @media (any-hover: hover) {
+    .#{$prefix}--side-nav__submenu:hover {
+      background-color: $shell-side-nav-bg-04;
+      color: $ibm-color__gray-100;
+    }
   }
 
   .#{$prefix}--side-nav__submenu:focus {
@@ -436,9 +456,11 @@
       font-weight: 400;
     }
 
-    a.#{$prefix}--header__menu-item:hover {
-      background-color: $shell-side-nav-bg-04;
-      color: $ibm-color__gray-100;
+    @media (any-hover: hover) {
+      a.#{$prefix}--header__menu-item:hover {
+        background-color: $shell-side-nav-bg-04;
+        color: $ibm-color__gray-100;
+      }
     }
   }
 
@@ -449,25 +471,36 @@
   }
 
   .#{$prefix}--side-nav
-    a.#{$prefix}--header__menu-item:hover
-    .#{$prefix}--header__menu-arrow,
-  .#{$prefix}--side-nav
     a.#{$prefix}--header__menu-item:focus
     .#{$prefix}--header__menu-arrow,
   .#{$prefix}--side-nav .#{$prefix}--header__menu-arrow {
     fill: $shell-side-nav-text-01;
   }
 
+  @media (any-hover: hover) {
+    .#{$prefix}--side-nav
+      a.#{$prefix}--header__menu-item:hover
+      .#{$prefix}--header__menu-arrow {
+      fill: $shell-side-nav-text-01;
+    }
+  }
+
   // Windows HCM fix
   .#{$prefix}--side-nav__icon > svg,
-  .#{$prefix}--side-nav
-    a.#{$prefix}--header__menu-item:hover
-    .#{$prefix}--header__menu-arrow,
   .#{$prefix}--side-nav
     a.#{$prefix}--header__menu-item:focus
     .#{$prefix}--header__menu-arrow,
   .#{$prefix}--side-nav .#{$prefix}--header__menu-arrow {
     @include high-contrast-mode('icon-fill');
+  }
+
+  // Windows HCM fix
+  @media (any-hover: hover) {
+    .#{$prefix}--side-nav
+      a.#{$prefix}--header__menu-item:hover
+      .#{$prefix}--header__menu-arrow {
+      @include high-contrast-mode('icon-fill');
+    }
   }
 }
 

--- a/css/vendor/carbon-components/scss/components/ui-shell/_switcher.scss
+++ b/css/vendor/carbon-components/scss/components/ui-shell/_switcher.scss
@@ -52,10 +52,12 @@
     color: $shell-panel-text-01;
     text-decoration: none;
 
-    &:hover:not(.#{$prefix}--switcher__item-link--selected) {
-      background: $shell-panel-bg-02;
-      color: $shell-panel-text-02;
-      cursor: pointer;
+    @media (any-hover: hover) {
+      &:hover:not(.#{$prefix}--switcher__item-link--selected) {
+        background: $shell-panel-bg-02;
+        color: $shell-panel-text-02;
+        cursor: pointer;
+      }
     }
 
     &:focus {


### PR DESCRIPTION
Wraps bare `:hover` selectors in `@media (any-hover: hover)` across
date-picker, tree-view, overflow-menu, pagination-nav, tag,
file-uploader, text-input, structured-list, ui-shell, and slider, so
hover styling doesn't stick after a tap on touch devices. Ports
carbon-design-system/carbon#22628 to this repo's vendored v10 SCSS.
