### PR TITLE
feat(big-number): add `BigNumber`

### DIFF
--- a/css/_big-number.scss
+++ b/css/_big-number.scss
@@ -1,0 +1,83 @@
+@import "carbon-components/scss/globals/scss/vars";
+@import "carbon-components/scss/globals/scss/functions";
+@import "carbon-components/scss/globals/scss/typography";
+@import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
+
+/// Big number (absent from v10; ported from `carbon-for-ibm-products`).
+/// A dashboard stat widget: a label, a large numeric value, and optional
+/// fraction/percentage/trend adornments.
+/// @access private
+/// @group components
+@mixin big-number {
+  .#{$prefix}--big-number {
+    margin: 0;
+  }
+
+  .#{$prefix}--big-number__label {
+    display: flex;
+    align-items: center;
+    gap: $carbon--spacing-02;
+    margin-block-end: $carbon--spacing-02;
+    color: $text-secondary;
+
+    @include type-style("body-short-01");
+  }
+
+  .#{$prefix}--big-number__value-row {
+    display: flex;
+    align-items: baseline;
+    gap: $carbon--spacing-02;
+    color: $text-primary;
+
+    @include type-style("productive-heading-05");
+  }
+
+  .#{$prefix}--big-number--lg .#{$prefix}--big-number__value-row {
+    @include type-style("productive-heading-06");
+  }
+
+  .#{$prefix}--big-number--xl .#{$prefix}--big-number__value-row {
+    @include type-style("productive-heading-07");
+  }
+
+  // The tooltip icon has no trigger text next to it, so the vendor
+  // text-to-icon spacing and its block-level wrapper (sized by the
+  // inherited line-height rather than the icon) are both unwanted here.
+  .#{$prefix}--big-number__tooltip {
+    display: inline-flex;
+    align-items: center;
+  }
+
+  .#{$prefix}--big-number__tooltip .#{$prefix}--tooltip__trigger {
+    margin-left: 0;
+  }
+
+  // Tooltip's own `top`-direction offset math bakes in a 1px fudge tuned
+  // for its default (text + icon) trigger; with an icon-only trigger the
+  // caret lands 1px left of the icon's true center.
+  .#{$prefix}--big-number__tooltip .#{$prefix}--tooltip--top {
+    transform: translateX(1px);
+  }
+
+  .#{$prefix}--big-number__denominator {
+    color: $text-secondary;
+
+    @include type-style("body-short-01");
+  }
+
+  .#{$prefix}--big-number__trend-icon {
+    align-self: center;
+  }
+
+  .#{$prefix}--big-number__trend-icon--success {
+    fill: $support-success;
+  }
+
+  .#{$prefix}--big-number__trend-icon--error {
+    fill: $support-error;
+  }
+}
+
+@include exports("big-number") {
+  @include big-number;
+}

--- a/css/all.scss
+++ b/css/all.scss
@@ -119,6 +119,7 @@ $css--plex: true;
 @import "./fluid-text-area";
 @import "./truncate-multiline";
 @import "./badge-indicator";
+@import "./big-number";
 @import "./icon-indicator";
 @import "./shape-indicator";
 @import "./type";

--- a/css/g10.scss
+++ b/css/g10.scss
@@ -79,6 +79,7 @@ $css--plex: true;
 @import "./fluid-text-area";
 @import "./truncate-multiline";
 @import "./badge-indicator";
+@import "./big-number";
 @import "./icon-indicator";
 @import "./shape-indicator";
 @import "./type";

--- a/css/g100.scss
+++ b/css/g100.scss
@@ -79,6 +79,7 @@ $css--plex: true;
 @import "./fluid-text-area";
 @import "./truncate-multiline";
 @import "./badge-indicator";
+@import "./big-number";
 @import "./icon-indicator";
 @import "./shape-indicator";
 @import "./type";

--- a/css/g80.scss
+++ b/css/g80.scss
@@ -79,6 +79,7 @@ $css--plex: true;
 @import "./fluid-text-area";
 @import "./truncate-multiline";
 @import "./badge-indicator";
+@import "./big-number";
 @import "./icon-indicator";
 @import "./shape-indicator";
 @import "./type";

--- a/css/g90.scss
+++ b/css/g90.scss
@@ -79,6 +79,7 @@ $css--plex: true;
 @import "./fluid-text-area";
 @import "./truncate-multiline";
 @import "./badge-indicator";
+@import "./big-number";
 @import "./icon-indicator";
 @import "./shape-indicator";
 @import "./type";

--- a/css/white.scss
+++ b/css/white.scss
@@ -79,6 +79,7 @@ $css--plex: true;
 @import "./fluid-text-area";
 @import "./truncate-multiline";
 @import "./badge-indicator";
+@import "./big-number";
 @import "./icon-indicator";
 @import "./shape-indicator";
 @import "./type";

--- a/docs/src/component-categories.ts
+++ b/docs/src/component-categories.ts
@@ -109,6 +109,10 @@ export const COMPONENT_CATEGORIES: ComponentCategory[] = [
     components: ["IconIndicator", "ShapeIndicator"],
   },
   {
+    label: "Data visualization",
+    components: ["BigNumber"],
+  },
+  {
     label: "Loading",
     components: [
       "Loading",

--- a/docs/src/component-since-versions.ts
+++ b/docs/src/component-since-versions.ts
@@ -3,6 +3,7 @@ export const COMPONENT_SINCE_VERSIONS: Record<string, string> = {
   ActionSet: "0.112.0",
   AspectRatio: "0.17.0",
   BadgeIndicator: "0.109.0",
+  BigNumber: "0.112.0",
   Box: "0.109.0",
   Breadcrumb: "0.2.0",
   Breakpoint: "0.40.0",

--- a/docs/src/pages/components/BigNumber.svx
+++ b/docs/src/pages/components/BigNumber.svx
@@ -1,0 +1,107 @@
+---
+components: ["BigNumber", "BigNumberSkeleton"]
+description: Big number displays a single prominent statistic, such as a dashboard metric or KPI, alongside an optional fraction, percentage, or trend indicator.
+---
+
+<script>
+  import { Stack, BigNumber } from "carbon-components-svelte";
+</script>
+
+## Basic
+
+Create a big number with `labelText` and `value`.
+
+<BigNumber labelText="Deployments" value={1240} />
+
+## Sizes
+
+Set `size` to control the visual weight of the value.
+
+### Default
+
+<BigNumber labelText="Deployments" value={1240} />
+
+### Large
+
+<BigNumber labelText="Deployments" value={1240} size="lg" />
+
+### Extra large
+
+<BigNumber labelText="Deployments" value={1240} size="xl" />
+
+## Custom label
+
+Use the `labelChildren` slot for custom label content instead of `labelText`.
+
+<BigNumber labelText="Deployments" value={1240}>
+  <strong slot="labelChildren">Custom label</strong>
+</BigNumber>
+
+## With total
+
+Set `total` to render `value` as the numerator of a "value / total" fraction. The denominator is hidden when it equals `value`, or when its truncated display would look identical to `value`'s. Set `forceShowTotal` to `true` to always render it.
+
+<Stack gap={5}>
+  <BigNumber labelText="Tickets resolved" value={42} total={120} />
+  <BigNumber labelText="Same after truncation" value={42} total={42} forceShowTotal />
+</Stack>
+
+## Percentage
+
+Set `percentage` to `true` to append a percent sign after `value` instead of rendering `total` as a fraction.
+
+<BigNumber labelText="Uptime" value={99.8} percentage />
+
+## Trending
+
+Set `trend` to `"up"` or `"down"` to render a trend indicator next to the value.
+
+### Default color
+
+By default, an upward trend is green and a downward trend is red.
+
+<Stack gap={5}>
+  <BigNumber labelText="Revenue" value={128000} trend="up" />
+  <BigNumber labelText="Uptime" value={99.8} percentage trend="down" />
+</Stack>
+
+### Overriding color
+
+A trend's direction and its meaning aren't always the same: more failed builds is bad even though the number is trending up, and a falling error rate is good even though it's trending down. Set `trendColor` to decouple the indicator's color from its direction.
+
+<Stack gap={5}>
+  <BigNumber labelText="Failed builds" value={12} trend="up" trendColor="error" />
+  <BigNumber
+    labelText="Error rate"
+    value={0.4}
+    percentage
+    trend="down"
+    trendColor="success"
+  />
+</Stack>
+
+## Truncation
+
+`value` and `total` abbreviate large numbers by default (for example, `12,400` becomes `12.4K`). Set `fullNumber` to `true` to render the full number instead, and `fractionDigits` to control the number of fraction digits used when formatting.
+
+<Stack gap={5}>
+  <BigNumber labelText="Abbreviated" value={12400} />
+  <BigNumber labelText="Full number" value={12400} fullNumber />
+</Stack>
+
+## Tooltip
+
+Set `tooltipDescription` to render an information icon next to `labelText` with additional context.
+
+<BigNumber
+  labelText="Error rate"
+  value={0.4}
+  percentage
+  tooltipDescription="Percentage of requests that returned a 5xx status in the last 24 hours."
+/>
+
+## Skeleton
+
+Set `loading` to `true` to render the skeleton state in place of the value.
+
+<BigNumber labelText="Deployments" value={1240} loading />

--- a/src/BigNumber/BigNumber.svelte
+++ b/src/BigNumber/BigNumber.svelte
@@ -1,0 +1,151 @@
+<script>
+  /** @restProps {figure} */
+
+  /**
+   * Text label rendered above the value.
+   * @type {string}
+   */
+  export let labelText;
+
+  /**
+   * The primary value to display (the "numerator" of a fraction).
+   * @type {number}
+   */
+  export let value = undefined;
+
+  /**
+   * The number to render after the slash (the "denominator" of a fraction).
+   * Hidden if it's the same as `value` or if `percentage` is `true`; see `forceShowTotal`.
+   * @type {number}
+   */
+  export let total = undefined;
+
+  /**
+   * Set to `true` to append a percent sign (%) after `value` and hide `total`.
+   */
+  export let percentage = false;
+
+  /**
+   * Set to `true` to show `total` even when the default visibility rule would hide it.
+   */
+  export let forceShowTotal = false;
+
+  /** Specify the number of fraction digits used when formatting `value` and `total`. */
+  export let fractionDigits = 1;
+
+  /** Set to `true` to render the full number instead of an abbreviated one (e.g. `1,000` instead of `1K`). */
+  export let fullNumber = false;
+
+  /**
+   * Render a trend indicator next to the value.
+   * @type {"up" | "down"}
+   */
+  export let trend = undefined;
+
+  /**
+   * Override the trend indicator's color. Defaults to `"success"` for `trend="up"` and
+   * `"error"` for `trend="down"` — set this when the direction's meaning is reversed for
+   * the metric (e.g. a falling error rate, or a rising failure count).
+   * @type {"success" | "error"}
+   */
+  export let trendColor = undefined;
+
+  /**
+   * Specify the size of the big number.
+   * @type {"default" | "lg" | "xl"}
+   */
+  export let size = "default";
+
+  /** Specify the tooltip text. When set, an information icon renders next to `labelText`. */
+  export let tooltipDescription = "";
+
+  /**
+   * Determines how `value` and `total` are formatted. Defaults to the runtime locale.
+   * @type {string}
+   */
+  export let locale = undefined;
+
+  /** Set to `true` to render the loading skeleton in place of the value. */
+  export let loading = false;
+
+  import ArrowDown from "../icons/ArrowDown.svelte";
+  import ArrowUp from "../icons/ArrowUp.svelte";
+  import Tooltip from "../Tooltip/Tooltip.svelte";
+  import BigNumberSkeleton from "./BigNumberSkeleton.svelte";
+
+  const DASH = "–";
+
+  function formatNumber(num, digits, doTruncate) {
+    if (typeof num !== "number" || Number.isNaN(num)) return undefined;
+    const options = { maximumFractionDigits: digits };
+    if (doTruncate) {
+      options.notation = "compact";
+      options.compactDisplay = "short";
+    }
+    return new Intl.NumberFormat(locale, options).format(num);
+  }
+
+  function getIconSize(currentSize) {
+    if (currentSize === "xl") return 24;
+    if (currentSize === "lg") return 20;
+    return 16;
+  }
+
+  $: hasTotal = typeof total === "number";
+  $: formattedValue = formatNumber(value, fractionDigits, !fullNumber);
+  $: formattedTotal = hasTotal
+    ? formatNumber(total, fractionDigits, !fullNumber)
+    : undefined;
+  $: showDenominator =
+    hasTotal &&
+    (forceShowTotal ||
+      (!percentage && total > value && formattedValue !== formattedTotal));
+  $: displayValue = `${formattedValue ?? DASH}${percentage ? "%" : ""}`;
+  $: resolvedTrendColor = trendColor ?? (trend === "up" ? "success" : "error");
+</script>
+
+{#if loading}
+  <BigNumberSkeleton {size} {...$$restProps} />
+{:else}
+  <figure
+    class:bx--big-number={true}
+    class:bx--big-number--lg={size === "lg"}
+    class:bx--big-number--xl={size === "xl"}
+    {...$$restProps}
+  >
+    <figcaption class:bx--big-number__label={true}>
+      <span class:bx--big-number__label-text={true}>
+        <slot name="labelChildren">{labelText}</slot>
+      </span>
+      {#if tooltipDescription}
+        <Tooltip
+          class="bx--big-number__tooltip"
+          iconDescription={tooltipDescription}
+          align="center"
+          direction="top"
+        >
+          {tooltipDescription}
+        </Tooltip>
+      {/if}
+    </figcaption>
+    <div class:bx--big-number__value-row={true} role="math">
+      <span class:bx--big-number__value={true}>{displayValue}</span>
+      {#if trend === "up"}
+        <ArrowUp
+          size={getIconSize(size)}
+          class="bx--big-number__trend-icon bx--big-number__trend-icon--{resolvedTrendColor}"
+          aria-hidden="true"
+        />
+      {:else if trend === "down"}
+        <ArrowDown
+          size={getIconSize(size)}
+          class="bx--big-number__trend-icon bx--big-number__trend-icon--{resolvedTrendColor}"
+          aria-hidden="true"
+        />
+      {/if}
+      {#if showDenominator}
+        <span class:bx--big-number__denominator={true}>/ {formattedTotal}</span>
+      {/if}
+    </div>
+  </figure>
+{/if}

--- a/src/BigNumber/BigNumberSkeleton.svelte
+++ b/src/BigNumber/BigNumberSkeleton.svelte
@@ -1,0 +1,26 @@
+<script>
+  /** @restProps {figure} */
+
+  /**
+   * Specify the size of the big number.
+   * @type {"default" | "lg" | "xl"}
+   */
+  export let size = "default";
+
+  import SkeletonText from "../SkeletonText/SkeletonText.svelte";
+</script>
+
+<figure
+  class:bx--big-number={true}
+  class:bx--big-number--lg={size === "lg"}
+  class:bx--big-number--xl={size === "xl"}
+  class:bx--skeleton={true}
+  {...$$restProps}
+>
+  <figcaption class:bx--big-number__label={true}>
+    <SkeletonText width="40%" />
+  </figcaption>
+  <div class:bx--big-number__value-row={true}>
+    <SkeletonText width="60%" heading />
+  </div>
+</figure>

--- a/src/BigNumber/index.js
+++ b/src/BigNumber/index.js
@@ -1,0 +1,2 @@
+export { default as BigNumber } from "./BigNumber.svelte";
+export { default as BigNumberSkeleton } from "./BigNumberSkeleton.svelte";

--- a/src/icons/ArrowDown.svelte
+++ b/src/icons/ArrowDown.svelte
@@ -1,0 +1,30 @@
+<script>
+  export let size = 16;
+
+  export let title = undefined;
+
+  $: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
+  $: attributes = {
+    "aria-hidden": labelled ? undefined : true,
+    role: labelled ? "img" : undefined,
+    focusable: Number($$props.tabindex) === 0 ? true : undefined,
+  };
+</script>
+
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 32 32"
+  fill="currentColor"
+  preserveAspectRatio="xMidYMid meet"
+  width={size}
+  height={size}
+  {...attributes}
+  {...$$restProps}
+>
+  {#if title}
+    <title>{title}</title>
+  {/if}
+  <path
+    d="M24.59 16.59 17 24.17 17 4 15 4 15 24.17 7.41 16.59 6 18 16 28 26 18 24.59 16.59z"
+  ></path>
+</svg>

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,8 @@ export { default as AccordionSkeleton } from "./Accordion/AccordionSkeleton.svel
 export { default as ActionSet } from "./ActionSet/ActionSet.svelte";
 export { default as AspectRatio } from "./AspectRatio/AspectRatio.svelte";
 export { default as BadgeIndicator } from "./BadgeIndicator/BadgeIndicator.svelte";
+export { default as BigNumber } from "./BigNumber/BigNumber.svelte";
+export { default as BigNumberSkeleton } from "./BigNumber/BigNumberSkeleton.svelte";
 export { default as Box } from "./Box/Box.svelte";
 export { default as Breadcrumb } from "./Breadcrumb/Breadcrumb.svelte";
 export { default as BreadcrumbItem } from "./Breadcrumb/BreadcrumbItem.svelte";

--- a/tests/BigNumber/BigNumber.test.svelte
+++ b/tests/BigNumber/BigNumber.test.svelte
@@ -1,0 +1,109 @@
+<script lang="ts">
+  import BigNumber from "carbon-components-svelte/BigNumber/BigNumber.svelte";
+</script>
+
+<BigNumber labelText="Basic" value={42} data-testid="basic" />
+
+<BigNumber labelText="No total" value={42} data-testid="no-total" />
+<BigNumber
+  labelText="Total shown"
+  value={3}
+  total={10}
+  data-testid="total-shown"
+/>
+<BigNumber
+  labelText="Total equal to value"
+  value={999}
+  total={999}
+  data-testid="total-equal"
+/>
+<BigNumber
+  labelText="Total less than value"
+  value={10}
+  total={3}
+  data-testid="total-less"
+/>
+<BigNumber
+  labelText="Total truncates the same as value"
+  value={1000000}
+  total={1040000}
+  data-testid="total-truncated-same"
+/>
+<BigNumber
+  labelText="Force show total"
+  value={999}
+  total={999}
+  forceShowTotal
+  data-testid="force-show-total"
+/>
+
+<BigNumber
+  labelText="Percentage"
+  value={42}
+  percentage
+  data-testid="percentage"
+/>
+<BigNumber
+  labelText="Percentage hides total"
+  value={3}
+  total={10}
+  percentage
+  data-testid="percentage-with-total"
+/>
+
+<BigNumber
+  labelText="Truncate thousands"
+  value={1500}
+  data-testid="truncate-thousands"
+/>
+<BigNumber
+  labelText="Truncate millions"
+  value={2500000}
+  data-testid="truncate-millions"
+/>
+<BigNumber
+  labelText="Full number"
+  value={1500}
+  fullNumber
+  data-testid="full-number"
+/>
+
+<BigNumber labelText="Trend up" value={42} trend="up" data-testid="trend-up" />
+<BigNumber
+  labelText="Trend down"
+  value={42}
+  trend="down"
+  data-testid="trend-down"
+/>
+<BigNumber labelText="No trend" value={42} data-testid="no-trend" />
+<BigNumber
+  labelText="Trend up, overridden to error"
+  value={42}
+  trend="up"
+  trendColor="error"
+  data-testid="trend-up-error"
+/>
+<BigNumber
+  labelText="Trend down, overridden to success"
+  value={42}
+  trend="down"
+  trendColor="success"
+  data-testid="trend-down-success"
+/>
+
+<BigNumber labelText="Loading" value={42} loading data-testid="loading" />
+
+<BigNumber
+  labelText="Tooltip"
+  value={42}
+  tooltipDescription="Extra context about this metric"
+  data-testid="tooltip"
+/>
+
+<BigNumber
+  labelText="Default label"
+  value={42}
+  data-testid="label-children-test"
+>
+  <strong slot="labelChildren">Custom label content</strong>
+</BigNumber>

--- a/tests/BigNumber/BigNumber.test.ts
+++ b/tests/BigNumber/BigNumber.test.ts
@@ -1,0 +1,183 @@
+import { render, screen } from "@testing-library/svelte";
+import BigNumber from "./BigNumber.test.svelte";
+
+describe("BigNumber", () => {
+  it("renders the label and value", () => {
+    render(BigNumber);
+
+    const basic = screen.getByTestId("basic");
+    expect(basic).toHaveClass("bx--big-number");
+    expect(basic).toHaveTextContent("Basic");
+    expect(basic.querySelector(".bx--big-number__value")).toHaveTextContent(
+      "42",
+    );
+  });
+
+  describe("denominator visibility", () => {
+    it("hides the denominator when there is no total", () => {
+      render(BigNumber);
+
+      const el = screen.getByTestId("no-total");
+      expect(el.querySelector(".bx--big-number__denominator")).toBeNull();
+    });
+
+    it("shows the denominator when total is greater than value and formats differently", () => {
+      render(BigNumber);
+
+      const el = screen.getByTestId("total-shown");
+      expect(
+        el.querySelector(".bx--big-number__denominator"),
+      ).toHaveTextContent("/ 10");
+    });
+
+    it("hides the denominator when total equals value", () => {
+      render(BigNumber);
+
+      const el = screen.getByTestId("total-equal");
+      expect(el.querySelector(".bx--big-number__denominator")).toBeNull();
+    });
+
+    it("hides the denominator when total is less than value", () => {
+      render(BigNumber);
+
+      const el = screen.getByTestId("total-less");
+      expect(el.querySelector(".bx--big-number__denominator")).toBeNull();
+    });
+
+    it("hides the denominator when its truncated display matches the value's", () => {
+      render(BigNumber);
+
+      const el = screen.getByTestId("total-truncated-same");
+      expect(el.querySelector(".bx--big-number__value")).toHaveTextContent(
+        "1M",
+      );
+      expect(el.querySelector(".bx--big-number__denominator")).toBeNull();
+    });
+
+    it("shows the denominator when forceShowTotal is set, even if it equals value", () => {
+      render(BigNumber);
+
+      const el = screen.getByTestId("force-show-total");
+      expect(
+        el.querySelector(".bx--big-number__denominator"),
+      ).toHaveTextContent("/ 999");
+    });
+  });
+
+  describe("percentage", () => {
+    it("appends a percent sign to the value", () => {
+      render(BigNumber);
+
+      const el = screen.getByTestId("percentage");
+      expect(el.querySelector(".bx--big-number__value")).toHaveTextContent(
+        "42%",
+      );
+    });
+
+    it("hides the total even when it would otherwise be shown", () => {
+      render(BigNumber);
+
+      const el = screen.getByTestId("percentage-with-total");
+      expect(el.querySelector(".bx--big-number__value")).toHaveTextContent(
+        "3%",
+      );
+      expect(el.querySelector(".bx--big-number__denominator")).toBeNull();
+    });
+  });
+
+  describe("truncate", () => {
+    it("abbreviates thousands", () => {
+      render(BigNumber);
+
+      const el = screen.getByTestId("truncate-thousands");
+      expect(el.querySelector(".bx--big-number__value")).toHaveTextContent(
+        "1.5K",
+      );
+    });
+
+    it("abbreviates millions", () => {
+      render(BigNumber);
+
+      const el = screen.getByTestId("truncate-millions");
+      expect(el.querySelector(".bx--big-number__value")).toHaveTextContent(
+        "2.5M",
+      );
+    });
+
+    it("renders the full number when fullNumber is set", () => {
+      render(BigNumber);
+
+      const el = screen.getByTestId("full-number");
+      expect(el.querySelector(".bx--big-number__value")).toHaveTextContent(
+        "1,500",
+      );
+    });
+  });
+
+  describe("trend", () => {
+    it("renders an up arrow colored success by default", () => {
+      render(BigNumber);
+
+      const el = screen.getByTestId("trend-up");
+      const icon = el.querySelector(".bx--big-number__trend-icon");
+      expect(icon).toHaveClass("bx--big-number__trend-icon--success");
+    });
+
+    it("renders a down arrow colored error by default", () => {
+      render(BigNumber);
+
+      const el = screen.getByTestId("trend-down");
+      const icon = el.querySelector(".bx--big-number__trend-icon");
+      expect(icon).toHaveClass("bx--big-number__trend-icon--error");
+    });
+
+    it("renders no trend icon by default", () => {
+      render(BigNumber);
+
+      const el = screen.getByTestId("no-trend");
+      expect(el.querySelector(".bx--big-number__trend-icon")).toBeNull();
+    });
+
+    it("overrides an up trend's color independent of direction", () => {
+      render(BigNumber);
+
+      const el = screen.getByTestId("trend-up-error");
+      const icon = el.querySelector(".bx--big-number__trend-icon");
+      expect(icon).toHaveClass("bx--big-number__trend-icon--error");
+    });
+
+    it("overrides a down trend's color independent of direction", () => {
+      render(BigNumber);
+
+      const el = screen.getByTestId("trend-down-success");
+      const icon = el.querySelector(".bx--big-number__trend-icon");
+      expect(icon).toHaveClass("bx--big-number__trend-icon--success");
+    });
+  });
+
+  it("renders the skeleton instead of the value when loading", () => {
+    render(BigNumber);
+
+    const el = screen.getByTestId("loading");
+    expect(el).toHaveClass("bx--skeleton");
+    expect(el.querySelector(".bx--big-number__value")).toBeNull();
+  });
+
+  it("renders an accessible tooltip from tooltipDescription", () => {
+    render(BigNumber);
+
+    const el = screen.getByTestId("tooltip");
+    const trigger = el.querySelector(
+      "[aria-label='Extra context about this metric']",
+    );
+    expect(trigger).toBeInTheDocument();
+  });
+
+  it("overrides the label with labelChildren", () => {
+    render(BigNumber);
+
+    const el = screen.getByTestId("label-children-test");
+    expect(screen.getByText("Custom label content")).toBeInTheDocument();
+    expect(el).not.toHaveTextContent("Default label");
+  });
+});


### PR DESCRIPTION
Dashboard-style stat widget with a label, a large value, and
optional value/total fraction, percentage, trend arrow, and info
tooltip. Ported from carbon-for-ibm-products via @carbon/react.
Includes a docs page and a new Data visualization sidebar category.

---

<img width="432" height="180" alt="Screenshot 2026-09-04 at 7 50 32 PM" src="https://github.com/user-attachments/assets/0b70efa0-8750-43f6-92d5-5901dceeda50" />
<img width="425" height="180" alt="Screenshot 2026-09-04 at 7 50 42 PM" src="https://github.com/user-attachments/assets/d4b86e74-15ba-4cad-94de-fa759ec21a58" />
