### PR TITLE
chore(accordion-item): guard title fallback against undefined coercion

### DIFF
--- a/src/Accordion/AccordionItem.svelte
+++ b/src/Accordion/AccordionItem.svelte
@@ -114,7 +114,7 @@
   >
     <ChevronRight class="bx--accordion__arrow" />
     <div class:bx--accordion__title={true}>
-      <slot name="title">{title}</slot>
+      <slot name="title">{title ?? ""}</slot>
     </div>
   </button>
   <div id={contentId} class:bx--accordion__content={true}>


### PR DESCRIPTION
Not a "fix" since it's a fast-follow to https://github.com/carbon-design-system/carbon-components-svelte/pull/3757

Setting a text node's data to undefined coerces to the literal string
"undefined" in the DOM, so the recent switch of the title default from
"title" to undefined rendered that string as the heading whenever no
title prop or slot was passed.