### PR TITLE
feat(scroll-gradient): add `ScrollGradient`

### DIFF
--- a/css/_scroll-gradient.scss
+++ b/css/_scroll-gradient.scss
@@ -1,0 +1,124 @@
+// New component: no equivalent exists in carbon-components v10, so this
+// partial is hand-written rather than ported from an upstream Sass file.
+
+@import "carbon-components/scss/globals/scss/vars";
+@import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
+
+/// ScrollGradient component
+/// @access private
+/// @group components
+@mixin scroll-gradient {
+  .#{$prefix}--scroll-gradient {
+    --cds-scroll-gradient-color: #{$layer};
+
+    position: relative;
+  }
+
+  .#{$prefix}--scroll-gradient__scroll-element {
+    height: 100%;
+    overflow: auto;
+    // Fixed to the theme background, independent of `--cds-scroll-gradient-color`:
+    // a custom `color` should only retint the fade, not repaint the content area.
+    background-color: $layer;
+  }
+
+  .#{$prefix}--scroll-gradient__content {
+    position: relative;
+    display: inline-block;
+    min-width: 100%;
+  }
+
+  .#{$prefix}--scroll-gradient__sentinel {
+    position: absolute;
+    pointer-events: none;
+  }
+
+  .#{$prefix}--scroll-gradient__content--v-scrollable
+    > .#{$prefix}--scroll-gradient__sentinel:nth-child(1) {
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 1px;
+  }
+
+  .#{$prefix}--scroll-gradient__content--v-scrollable
+    > .#{$prefix}--scroll-gradient__sentinel:nth-child(2) {
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 1px;
+  }
+
+  .#{$prefix}--scroll-gradient__content--h-scrollable
+    > .#{$prefix}--scroll-gradient__sentinel:nth-child(3) {
+    top: 0;
+    bottom: 0;
+    left: 0;
+    width: 1px;
+  }
+
+  .#{$prefix}--scroll-gradient__content--h-scrollable
+    > .#{$prefix}--scroll-gradient__sentinel:nth-child(4) {
+    top: 0;
+    bottom: 0;
+    right: 0;
+    width: 1px;
+  }
+
+  .#{$prefix}--scroll-gradient__gradient {
+    position: absolute;
+    pointer-events: none;
+  }
+
+  .#{$prefix}--scroll-gradient__gradient--top,
+  .#{$prefix}--scroll-gradient__gradient--bottom {
+    left: 0;
+    right: 0;
+    height: $spacing-09;
+  }
+
+  .#{$prefix}--scroll-gradient__gradient--left,
+  .#{$prefix}--scroll-gradient__gradient--right {
+    top: 0;
+    bottom: 0;
+    width: $spacing-09;
+  }
+
+  .#{$prefix}--scroll-gradient__gradient--top {
+    top: 0;
+    background-image: linear-gradient(
+      to bottom,
+      var(--cds-scroll-gradient-color),
+      transparent
+    );
+  }
+
+  .#{$prefix}--scroll-gradient__gradient--bottom {
+    bottom: 0;
+    background-image: linear-gradient(
+      to top,
+      var(--cds-scroll-gradient-color),
+      transparent
+    );
+  }
+
+  .#{$prefix}--scroll-gradient__gradient--left {
+    left: 0;
+    background-image: linear-gradient(
+      to right,
+      var(--cds-scroll-gradient-color),
+      transparent
+    );
+  }
+
+  .#{$prefix}--scroll-gradient__gradient--right {
+    right: 0;
+    background-image: linear-gradient(
+      to left,
+      var(--cds-scroll-gradient-color),
+      transparent
+    );
+  }
+}
+
+@include scroll-gradient;

--- a/css/all.scss
+++ b/css/all.scss
@@ -43,6 +43,7 @@ $css--plex: true;
 @import "./content-switcher";
 @import "./tooltip";
 @import "./toggletip";
+@import "./scroll-gradient";
 
 // Default: white
 :root {

--- a/css/g10.scss
+++ b/css/g10.scss
@@ -43,6 +43,7 @@ $css--plex: true;
 @import "./content-switcher";
 @import "./tooltip";
 @import "./toggletip";
+@import "./scroll-gradient";
 
 @import "carbon-components/scss/globals/scss/_css--reset";
 @import "carbon-components/scss/globals/scss/_css--font-face";

--- a/css/g100.scss
+++ b/css/g100.scss
@@ -43,6 +43,7 @@ $css--plex: true;
 @import "./content-switcher";
 @import "./tooltip";
 @import "./toggletip";
+@import "./scroll-gradient";
 
 @import "carbon-components/scss/globals/scss/_css--reset";
 @import "carbon-components/scss/globals/scss/_css--font-face";

--- a/css/g80.scss
+++ b/css/g80.scss
@@ -43,6 +43,7 @@ $css--plex: true;
 @import "./content-switcher";
 @import "./tooltip";
 @import "./toggletip";
+@import "./scroll-gradient";
 
 @import "carbon-components/scss/globals/scss/_css--reset";
 @import "carbon-components/scss/globals/scss/_css--font-face";

--- a/css/g90.scss
+++ b/css/g90.scss
@@ -43,6 +43,7 @@ $css--plex: true;
 @import "./content-switcher";
 @import "./tooltip";
 @import "./toggletip";
+@import "./scroll-gradient";
 
 @import "carbon-components/scss/globals/scss/_css--reset";
 @import "carbon-components/scss/globals/scss/_css--font-face";

--- a/css/white.scss
+++ b/css/white.scss
@@ -43,6 +43,7 @@ $css--plex: true;
 @import "./content-switcher";
 @import "./tooltip";
 @import "./toggletip";
+@import "./scroll-gradient";
 
 @import "carbon-components/scss/globals/scss/_css--reset";
 @import "carbon-components/scss/globals/scss/_css--font-face";

--- a/docs/src/component-categories.ts
+++ b/docs/src/component-categories.ts
@@ -27,6 +27,7 @@ export const COMPONENT_CATEGORIES: ComponentCategory[] = [
       "Stack",
       "Box",
       "AspectRatio",
+      "ScrollGradient",
       "Accordion",
       "Disclosure",
     ],

--- a/docs/src/component-since-versions.ts
+++ b/docs/src/component-since-versions.ts
@@ -57,6 +57,7 @@ export const COMPONENT_SINCE_VERSIONS: Record<string, string> = {
   RadioButton: "0.2.0",
   RadioTile: "0.2.0",
   RecursiveList: "0.39.0",
+  ScrollGradient: "0.112.0",
   Search: "0.2.0",
   SearchMenu: "0.110.0",
   Select: "0.2.0",

--- a/docs/src/pages/components/ScrollGradient.svx
+++ b/docs/src/pages/components/ScrollGradient.svx
@@ -1,0 +1,47 @@
+---
+description: ScrollGradient overlays a fading gradient at the edges of a scrollable container to hint that there's more content, hiding each edge's gradient once it's scrolled into view.
+---
+
+<script>
+  import { ScrollGradient } from "carbon-components-svelte";
+</script>
+
+## Basic
+
+Wrap scrollable content in `ScrollGradient`. Set a height on the component so the content overflows vertically. The top gradient appears once the content is scrolled past its start, and the bottom gradient hides once it's scrolled to the end.
+
+<ScrollGradient style="height: 12rem">
+  {#each Array(20) as _, i}
+    <p>Item {i + 1}</p>
+  {/each}
+</ScrollGradient>
+
+## Horizontal
+
+Gradients appear independently for each axis. Set a width to overflow horizontally.
+
+<ScrollGradient style="width: 100%; height: 6rem">
+  <div style="display: flex; gap: 1rem; width: max-content">
+    {#each Array(20) as _, i}
+      <div style="width: 6rem; height: 4rem; background: var(--cds-layer-accent, #e0e0e0); display: flex; align-items: center; justify-content: center">
+        {i + 1}
+      </div>
+    {/each}
+  </div>
+</ScrollGradient>
+
+## Custom color
+
+Set `color` to override the gradient color. Defaults to the `layer` theme token.
+
+<ScrollGradient color="cornflowerblue" style="height: 12rem">
+  {#each Array(20) as _, i}
+    <p>Item {i + 1}</p>
+  {/each}
+</ScrollGradient>
+
+## Reactive example
+
+Toggling content demonstrates that the gradients update as the container's overflow changes.
+
+<FileSource src="/framed/ScrollGradient/ReactiveScrollGradient" />

--- a/docs/src/pages/framed/ScrollGradient/ReactiveScrollGradient.svelte
+++ b/docs/src/pages/framed/ScrollGradient/ReactiveScrollGradient.svelte
@@ -1,0 +1,33 @@
+<script>
+  import {
+    Button,
+    Checkbox,
+    ScrollGradient,
+    Stack,
+  } from "carbon-components-svelte";
+
+  let itemCount = 3;
+  let hideStartGradient = false;
+</script>
+
+<Stack gap={5}>
+  <Stack gap={3} orientation="horizontal">
+    <Button size="small" kind="tertiary" on:click={() => (itemCount += 1)}>
+      Add item
+    </Button>
+    <Button
+      size="small"
+      kind="tertiary"
+      disabled={itemCount === 0}
+      on:click={() => (itemCount = Math.max(0, itemCount - 1))}
+    >
+      Remove item
+    </Button>
+  </Stack>
+  <Checkbox labelText="Hide start gradient" bind:checked={hideStartGradient} />
+  <ScrollGradient {hideStartGradient} style="height: 8rem">
+    {#each Array(itemCount) as _, i}
+      <p>Item {i + 1}</p>
+    {/each}
+  </ScrollGradient>
+</Stack>

--- a/src/ScrollGradient/ScrollGradient.svelte
+++ b/src/ScrollGradient/ScrollGradient.svelte
@@ -1,0 +1,168 @@
+<script>
+  /**
+   * @slot {{}}
+   */
+
+  /**
+   * Specify the gradient color.
+   * Defaults to the `layer` theme token.
+   * @type {string | undefined}
+   */
+  export let color = undefined;
+
+  /**
+   * Set to `true` to suppress the top and left gradients,
+   * even when their edge is scrollable.
+   */
+  export let hideStartGradient = false;
+
+  /**
+   * Specify a class for the inner scrollable element.
+   * @type {string | undefined}
+   */
+  export let scrollElementClassName = undefined;
+
+  import { onMount } from "svelte";
+
+  let scrollRef = null;
+  let sentinelTop = null;
+  let sentinelBottom = null;
+  let sentinelLeft = null;
+  let sentinelRight = null;
+
+  let xScrollable = false;
+  let yScrollable = false;
+  let atTop = true;
+  let atBottom = true;
+  let atLeft = true;
+  let atRight = true;
+
+  $: showTopGradient = yScrollable && !hideStartGradient && !atTop;
+  $: showBottomGradient = yScrollable && !atBottom;
+  $: showLeftGradient = xScrollable && !hideStartGradient && !atLeft;
+  $: showRightGradient = xScrollable && !atRight;
+
+  $: style = color
+    ? `--cds-scroll-gradient-color: ${color};${
+        $$restProps.style ? ` ${$$restProps.style}` : ""
+      }`
+    : $$restProps.style;
+
+  function updateScrollable() {
+    if (!scrollRef) return;
+    xScrollable = scrollRef.scrollWidth > scrollRef.clientWidth;
+    yScrollable = scrollRef.scrollHeight > scrollRef.clientHeight;
+  }
+
+  onMount(() => {
+    updateScrollable();
+
+    const resizeObserver = new ResizeObserver(updateScrollable);
+    resizeObserver.observe(scrollRef);
+
+    const mutationObserver = new MutationObserver(updateScrollable);
+    mutationObserver.observe(scrollRef, { childList: true, subtree: true });
+
+    const intersectionObserver = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.target === sentinelTop) {
+            atTop = entry.isIntersecting;
+          } else if (entry.target === sentinelBottom) {
+            atBottom = entry.isIntersecting;
+          } else if (entry.target === sentinelLeft) {
+            atLeft = entry.isIntersecting;
+          } else if (entry.target === sentinelRight) {
+            atRight = entry.isIntersecting;
+          }
+        }
+      },
+      { root: scrollRef },
+    );
+
+    for (const sentinel of [
+      sentinelTop,
+      sentinelBottom,
+      sentinelLeft,
+      sentinelRight,
+    ]) {
+      intersectionObserver.observe(sentinel);
+    }
+
+    return () => {
+      resizeObserver.disconnect();
+      mutationObserver.disconnect();
+      intersectionObserver.disconnect();
+    };
+  });
+</script>
+
+<div
+  class:bx--scroll-gradient={true}
+  role="presentation"
+  {...$$restProps}
+  {style}
+>
+  <div
+    class:bx--scroll-gradient__scroll-element={true}
+    class={scrollElementClassName}
+    bind:this={scrollRef}
+    on:scroll
+  >
+    <div
+      class:bx--scroll-gradient__content={true}
+      class:bx--scroll-gradient__content--v-scrollable={yScrollable}
+      class:bx--scroll-gradient__content--h-scrollable={xScrollable}
+    >
+      <div
+        class:bx--scroll-gradient__sentinel={true}
+        bind:this={sentinelTop}
+      ></div>
+      <div
+        class:bx--scroll-gradient__sentinel={true}
+        bind:this={sentinelBottom}
+      ></div>
+      <div
+        class:bx--scroll-gradient__sentinel={true}
+        bind:this={sentinelLeft}
+      ></div>
+      <div
+        class:bx--scroll-gradient__sentinel={true}
+        bind:this={sentinelRight}
+      ></div>
+      <slot />
+    </div>
+  </div>
+  {#if showTopGradient}
+    <div
+      class:bx--scroll-gradient__gradient={true}
+      class:bx--scroll-gradient__gradient--top={true}
+      role="presentation"
+      aria-hidden="true"
+    ></div>
+  {/if}
+  {#if showBottomGradient}
+    <div
+      class:bx--scroll-gradient__gradient={true}
+      class:bx--scroll-gradient__gradient--bottom={true}
+      role="presentation"
+      aria-hidden="true"
+    ></div>
+  {/if}
+  {#if showLeftGradient}
+    <div
+      class:bx--scroll-gradient__gradient={true}
+      class:bx--scroll-gradient__gradient--left={true}
+      role="presentation"
+      aria-hidden="true"
+    ></div>
+  {/if}
+  {#if showRightGradient}
+    <div
+      class:bx--scroll-gradient__gradient={true}
+      class:bx--scroll-gradient__gradient--right={true}
+      role="presentation"
+      aria-hidden="true"
+    ></div>
+  {/if}
+</div>

--- a/src/ScrollGradient/index.js
+++ b/src/ScrollGradient/index.js
@@ -1,0 +1,1 @@
+export { default as ScrollGradient } from "./ScrollGradient.svelte";

--- a/src/index.js
+++ b/src/index.js
@@ -134,6 +134,7 @@ export { default as RadioButton } from "./RadioButton/RadioButton.svelte";
 export { default as RadioButtonSkeleton } from "./RadioButton/RadioButtonSkeleton.svelte";
 export { default as RadioButtonGroup } from "./RadioButtonGroup/RadioButtonGroup.svelte";
 export { default as RecursiveList } from "./RecursiveList/RecursiveList.svelte";
+export { default as ScrollGradient } from "./ScrollGradient/ScrollGradient.svelte";
 export { default as FluidSearchSkeleton } from "./Search/FluidSearchSkeleton.svelte";
 export { default as Search } from "./Search/Search.svelte";
 export { default as SearchSkeleton } from "./Search/SearchSkeleton.svelte";

--- a/tests/ScrollGradient/ScrollGradient.test.svelte
+++ b/tests/ScrollGradient/ScrollGradient.test.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import ScrollGradient from "carbon-components-svelte/ScrollGradient/ScrollGradient.svelte";
+
+  export let color: string | undefined = undefined;
+  export let hideStartGradient = false;
+</script>
+
+<ScrollGradient {color} {hideStartGradient}>
+  <p>Content</p>
+</ScrollGradient>

--- a/tests/ScrollGradient/ScrollGradient.test.ts
+++ b/tests/ScrollGradient/ScrollGradient.test.ts
@@ -1,0 +1,189 @@
+import { render } from "@testing-library/svelte";
+import { tick } from "svelte";
+import ScrollGradient from "./ScrollGradient.test.svelte";
+
+class IntersectionObserverMock {
+  static instances: IntersectionObserverMock[] = [];
+
+  callback: IntersectionObserverCallback;
+  options?: IntersectionObserverInit;
+  elements = new Set<Element>();
+
+  constructor(
+    callback: IntersectionObserverCallback,
+    options?: IntersectionObserverInit,
+  ) {
+    this.callback = callback;
+    this.options = options;
+    IntersectionObserverMock.instances.push(this);
+  }
+
+  observe(element: Element) {
+    this.elements.add(element);
+  }
+
+  unobserve(element: Element) {
+    this.elements.delete(element);
+  }
+
+  disconnect() {
+    this.elements.clear();
+  }
+
+  trigger(target: Element, isIntersecting: boolean) {
+    this.callback(
+      [{ target, isIntersecting } as IntersectionObserverEntry],
+      this as unknown as IntersectionObserver,
+    );
+  }
+}
+
+beforeEach(() => {
+  IntersectionObserverMock.instances = [];
+  vi.stubGlobal("IntersectionObserver", IntersectionObserverMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+/** Fake overflow on `element` and let the mocked `ResizeObserver` report it. */
+async function markScrollable(
+  element: HTMLElement,
+  { x = false, y = false }: { x?: boolean; y?: boolean },
+) {
+  Object.defineProperty(element, "clientWidth", {
+    value: 100,
+    configurable: true,
+  });
+  Object.defineProperty(element, "scrollWidth", {
+    value: x ? 200 : 100,
+    configurable: true,
+  });
+  Object.defineProperty(element, "clientHeight", {
+    value: 100,
+    configurable: true,
+  });
+  Object.defineProperty(element, "scrollHeight", {
+    value: y ? 200 : 100,
+    configurable: true,
+  });
+  // The ResizeObserver mock delivers its first callback on a microtask.
+  await Promise.resolve();
+  await tick();
+}
+
+/** [top, bottom, left, right], matching the component's sentinel markup order. */
+function getSentinels(container: HTMLElement) {
+  return Array.from(
+    container.querySelectorAll(".bx--scroll-gradient__sentinel"),
+  );
+}
+
+function getObserverFor(scrollElement: Element) {
+  const observer = IntersectionObserverMock.instances.find(
+    (instance) => instance.options?.root === scrollElement,
+  );
+  if (!observer) throw new Error("No IntersectionObserver found for root");
+  return observer;
+}
+
+describe("ScrollGradient", () => {
+  it("shows no gradients when content does not overflow", async () => {
+    const { container } = render(ScrollGradient);
+    await tick();
+
+    expect(
+      container.querySelectorAll(".bx--scroll-gradient__gradient"),
+    ).toHaveLength(0);
+  });
+
+  it("shows the top and bottom gradients once scrolled past the start", async () => {
+    const { container } = render(ScrollGradient);
+    const scrollElement = container.querySelector(
+      ".bx--scroll-gradient__scroll-element",
+    ) as HTMLElement;
+
+    await markScrollable(scrollElement, { y: true });
+    expect(
+      container.querySelectorAll(".bx--scroll-gradient__gradient"),
+    ).toHaveLength(0);
+
+    const [top, bottom] = getSentinels(container);
+    const observer = getObserverFor(scrollElement);
+
+    observer.trigger(top, false);
+    await tick();
+    expect(
+      container.querySelector(".bx--scroll-gradient__gradient--top"),
+    ).not.toBeNull();
+    expect(
+      container.querySelector(".bx--scroll-gradient__gradient--bottom"),
+    ).toBeNull();
+
+    observer.trigger(bottom, false);
+    await tick();
+    expect(
+      container.querySelector(".bx--scroll-gradient__gradient--bottom"),
+    ).not.toBeNull();
+
+    observer.trigger(top, true);
+    await tick();
+    expect(
+      container.querySelector(".bx--scroll-gradient__gradient--top"),
+    ).toBeNull();
+  });
+
+  it("suppresses the top and left gradients when hideStartGradient is set", async () => {
+    const { container } = render(ScrollGradient, {
+      props: { hideStartGradient: true },
+    });
+    const scrollElement = container.querySelector(
+      ".bx--scroll-gradient__scroll-element",
+    ) as HTMLElement;
+
+    await markScrollable(scrollElement, { x: true, y: true });
+    const [top, bottom, left, right] = getSentinels(container);
+    const observer = getObserverFor(scrollElement);
+
+    observer.trigger(top, false);
+    observer.trigger(bottom, false);
+    observer.trigger(left, false);
+    observer.trigger(right, false);
+    await tick();
+
+    expect(
+      container.querySelector(".bx--scroll-gradient__gradient--top"),
+    ).toBeNull();
+    expect(
+      container.querySelector(".bx--scroll-gradient__gradient--left"),
+    ).toBeNull();
+    expect(
+      container.querySelector(".bx--scroll-gradient__gradient--bottom"),
+    ).not.toBeNull();
+    expect(
+      container.querySelector(".bx--scroll-gradient__gradient--right"),
+    ).not.toBeNull();
+  });
+
+  it("applies the color prop to the gradient overlays", async () => {
+    const { container } = render(ScrollGradient, {
+      props: { color: "red" },
+    });
+    const scrollElement = container.querySelector(
+      ".bx--scroll-gradient__scroll-element",
+    ) as HTMLElement;
+
+    await markScrollable(scrollElement, { y: true });
+    const [top] = getSentinels(container);
+    getObserverFor(scrollElement).trigger(top, false);
+    await tick();
+
+    const wrapper = container.querySelector(
+      ".bx--scroll-gradient",
+    ) as HTMLElement;
+    expect(wrapper.style.getPropertyValue("--cds-scroll-gradient-color")).toBe(
+      "red",
+    );
+  });
+});


### PR DESCRIPTION
Ports ScrollGradient from carbon-for-ibm-products, migrated into
@carbon/react v11.115.0. No v10 equivalent existed, so this adds a
hand-written SCSS partial alongside the component and its docs page.

---

<img width="967" height="228" alt="Screenshot 2026-09-04 at 6 55 04 PM" src="https://github.com/user-attachments/assets/0062e61b-b40a-447b-a47a-ff17e96ab1e2" />
