### PR TITLE
fix(date-picker): drop opacity fade from calendar open animation

### DIFF
--- a/css/vendor/carbon-components/scss/components/date-picker/_flatpickr.scss
+++ b/css/vendor/carbon-components/scss/components/date-picker/_flatpickr.scss
@@ -11,13 +11,11 @@
 @keyframes fpFadeInDown {
   from {
     transform: translate3d(0, -20px, 0);
-    opacity: 0;
   }
   to {
     transform: translate3d(0, 0, 0);
-    opacity: 1;
   }
-}
+} // ccs: opacity fade blended selected-day text/bg against the page during the transition, sampling below 4.5:1 mid-animation; transform-only keeps colors solid throughout
 
 @keyframes fpSlideLeft {
   from {


### PR DESCRIPTION
Mid-fade the selected day's blue/white blended against the page and
dipped below the 4.5:1 contrast minimum, which flaked
e2e/a11y-date-picker.test.ts on roughly one in three runs. The
settled color pairing was already compliant, so only the keyframe's
opacity tween needed to go.