### PR TITLE
chore(icons): rename Menu icon to MenuIcon to dodge sveld name clash

### DIFF
--- a/src/UIShell/HamburgerMenu.svelte
+++ b/src/UIShell/HamburgerMenu.svelte
@@ -29,7 +29,7 @@
 
   import { onMount } from "svelte";
   import Close from "../icons/Close.svelte";
-  import Menu from "../icons/Menu.svelte";
+  import Menu from "../icons/MenuIcon.svelte";
   import { hamburgerMenuRef } from "./nav-store.js";
 
   $: hamburgerMenuRef.set(ref);

--- a/src/UIShell/Header.svelte
+++ b/src/UIShell/Header.svelte
@@ -98,7 +98,7 @@
   export let theme = undefined;
 
   import Close from "../icons/Close.svelte";
-  import Menu from "../icons/Menu.svelte";
+  import Menu from "../icons/MenuIcon.svelte";
   import HamburgerMenu from "./HamburgerMenu.svelte";
   import { shouldRenderHamburgerMenu } from "./nav-store";
 

--- a/src/icons/MenuIcon.svelte
+++ b/src/icons/MenuIcon.svelte
@@ -1,3 +1,4 @@
+<!-- Named "Menu" in carbon-icons-svelte; renamed here to avoid a sveld glob name clash with src/Menu/Menu.svelte -->
 <script>
   export let size = 16;
 


### PR DESCRIPTION
sveld's glob scan globs every .svelte file under src and keys them
by filename. src/icons/Menu.svelte shared its name with the public
src/Menu/Menu.svelte, so sveld warned that only one could be the
named "Menu" export in the generated types. The icon isn't part of
the public API, so it's the one renamed, with a comment noting its
original carbon-icons-svelte name for anyone searching for it.