### PR TITLE
chore(deps-dev): upgrade ostia to 0.2.3

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,7 @@
         "culls": "^0.2.0",
         "jsdom": "^30.0.1",
         "lightningcss": "^1.33.0",
-        "ostia": "^0.2.0",
+        "ostia": "^0.2.3",
         "sass-embedded": "^1.103.1",
         "sveld": "^0.36.11",
         "svelte": "^5.57.0",
@@ -363,7 +363,7 @@
 
     "obug": ["obug@2.1.4", "", {}, "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA=="],
 
-    "ostia": ["ostia@0.2.0", "", { "bin": { "ostia": "cli.js" } }, "sha512-X+kqTYBmK7r0RgLLy5kqXFxrg0drR39ldOW9+i4H2Nnz4xU1dozsrqaz6pxm6wvlcAoSMIGKWFCYMWMkH+4rmA=="],
+    "ostia": ["ostia@0.2.3", "", { "bin": { "ostia": "cli.js" } }, "sha512-o/zO4BQDn9RKmo3RYjmLvohT4/41RRBK/1pIgAeZ6ok98g1386ywS9JAgkzJRPXkXxYkvemIm4E8dnfuDBEHRw=="],
 
     "parse5": ["parse5@8.0.1", "", { "dependencies": { "entities": "^8.0.0" } }, "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw=="],
 

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "culls": "^0.2.0",
     "jsdom": "^30.0.1",
     "lightningcss": "^1.33.0",
-    "ostia": "^0.2.0",
+    "ostia": "^0.2.3",
     "sass-embedded": "^1.103.1",
     "sveld": "^0.36.11",
     "svelte": "^5.57.0",


### PR DESCRIPTION
Bumps the bench-runner dep from 0.2.0. Only the bench CLI/config
surface is used here (ostia bench with suites/preload/jobs), and none
of the 0.2.3 changes (baseline hashing, time/compare/ci exit codes,
compareDocuments shape, timeSource regex flags, CPU viz formats,
minimum Bun) touch that surface, so no other files change.