### PR TITLE
fix(search): prevent disabled expandable search from expanding

### DIFF
--- a/src/Search/Search.svelte
+++ b/src/Search/Search.svelte
@@ -139,7 +139,7 @@
       bind:this={searchRef}
       class:bx--search-magnifier={true}
       on:click={() => {
-        if (expandable) expanded = true;
+        if (expandable && !disabled) expanded = true;
       }}
     >
       <svelte:component this={icon} class="bx--search-magnifier-icon" />
@@ -170,7 +170,7 @@
       on:input
       on:focus
       on:focus={() => {
-        if (expandable) expanded = true;
+        if (expandable && !disabled) expanded = true;
       }}
       on:blur
       on:blur={() => {

--- a/tests/Search/Search.test.ts
+++ b/tests/Search/Search.test.ts
@@ -113,6 +113,20 @@ describe("Search", () => {
     expect(searchWrapper).toHaveClass("bx--search--expanded");
   });
 
+  it("does not expand a disabled expandable search on magnifier click", async () => {
+    render(SearchExpandable, { props: { disabled: true } });
+
+    const search = getSearchInput("Expandable search");
+    const searchWrapper = search.closest(".bx--search");
+    assert(searchWrapper);
+
+    const magnifier = searchWrapper.querySelector(".bx--search-magnifier");
+    assert(magnifier);
+
+    await user.click(magnifier);
+    expect(searchWrapper).not.toHaveClass("bx--search--expanded");
+  });
+
   it("hides the collapsed expandable input from assistive tech", async () => {
     render(SearchExpandable);
 

--- a/tests/Search/SearchExpandable.test.svelte
+++ b/tests/Search/SearchExpandable.test.svelte
@@ -2,6 +2,7 @@
   import Search from "carbon-components-svelte/Search/Search.svelte";
 
   export let fluid = false;
+  export let disabled = false;
 
   let expanded = false;
   let value = "";
@@ -12,6 +13,7 @@
   bind:value
   expandable
   {fluid}
+  {disabled}
   labelText="Expandable search"
   placeholder="Search expandable..."
   on:expand={() => {


### PR DESCRIPTION
The magnifier icon's click handler and the input's focus handler
set `expanded = true` without checking `disabled`. Now both bail
out when the Search is disabled, matching the upstream
carbon-react/web-components fix (PR #23172).