### PR TITLE
fix(data-table): resize every toolbar button kind at short/compact

### DIFF
--- a/css/vendor/carbon-components/scss/components/data-table/_data-table-action.scss
+++ b/css/vendor/carbon-components/scss/components/data-table/_data-table-action.scss
@@ -520,8 +520,8 @@
   }
 
   // V11: remove --small selector block
-  .#{$prefix}--table-toolbar--small .#{$prefix}--btn--primary,
-  .#{$prefix}--table-toolbar--sm .#{$prefix}--btn--primary {
+  .#{$prefix}--table-toolbar--small .#{$prefix}--btn, // ccs: resize every button kind, not only primary
+  .#{$prefix}--table-toolbar--sm .#{$prefix}--btn {
     height: to-rem(32px);
     min-height: auto;
     padding-top: calc(0.375rem - 3px);
@@ -671,7 +671,8 @@
     padding: $spacing-02 0;
   }
 
-  .#{$prefix}--table-toolbar--xs .#{$prefix}--btn--primary {
+  // ccs: resize every button kind, not only primary
+  .#{$prefix}--table-toolbar--xs .#{$prefix}--btn {
     height: $spacing-06;
     min-height: auto;
     padding-top: 0;

--- a/docs/src/pages/components/DataTable.svx
+++ b/docs/src/pages/components/DataTable.svx
@@ -687,6 +687,38 @@ Use `size="short"` for a more compact table. The toolbar inherits a matching siz
   </Toolbar>
 </DataTable>
 
+### Small (button kinds)
+
+Buttons of every kind resize to match the small toolbar, not only `kind="primary"`.
+
+<DataTable size="short" title="Load balancers" description="Your organization's active load balancers."
+  headers="{[
+    { key: "name", value: "Name" },
+    { key: "protocol", value: "Protocol" },
+    { key: "port", value: "Port" },
+    { key: "rule", value: "Rule" }
+  ]}"
+  rows="{[
+    {
+      id: "a",
+      name: "Load Balancer 3",
+      protocol: "HTTP",
+      port: 3000,
+      rule: "Round robin"
+    },
+  ]}"
+>
+  <Toolbar>
+    <ToolbarContent>
+      <Button kind="primary">Primary</Button>
+      <Button kind="secondary">Secondary</Button>
+      <Button kind="tertiary">Tertiary</Button>
+      <Button kind="danger">Danger</Button>
+      <Button kind="ghost">Ghost</Button>
+    </ToolbarContent>
+  </Toolbar>
+</DataTable>
+
 ### Size override
 
 Set `size` on the toolbar to override the size inherited from the DataTable. Here, `size="tall"` on the table pairs with `size="sm"` on the toolbar.


### PR DESCRIPTION
Fixes #3778

At `size="short"` or `size="compact"`, the DataTable toolbar
shrinks to match the row height. But only `kind="primary"`
buttons shrank with it. A `secondary`, `tertiary`, `ghost`, or
`danger` button placed directly in `ToolbarContent` kept its
full 48px height and overflowed the toolbar.



## Fix

Widen the height-override selector in
`_data-table-action.scss` from `.bx--btn--primary` to
`.bx--btn`, for both the small (`short`) and extra small
(`compact`) toolbar sizes. All Carbon v10 button kinds share
the same vertical padding, only horizontal padding differs
(ghost buttons), so this is safe across kinds.

Also adds a "Small (button kinds)" example to `DataTable.svx`,
showing every button kind in a short toolbar.

---

<img width="1045" height="254" alt="Screenshot 2026-09-09 at 9 29 57 AM" src="https://github.com/user-attachments/assets/b1ba06df-9e36-4437-8480-f207875a7564" />
