### PR TITLE
fix(data-table): keep expand column width stable with custom header widths

### DIFF
--- a/css/vendor/carbon-components/scss/components/data-table/_data-table.scss
+++ b/css/vendor/carbon-components/scss/components/data-table/_data-table.scss
@@ -324,3 +324,29 @@
 @include exports("data-table-align") {
   @include data-table-align;
 }
+
+// carbon-components-svelte patch (DataTable fixed layout)
+@import "carbon-components/scss/globals/scss/vars";
+@import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
+
+/// Fixed layout for `DataTable` when a header specifies an explicit
+/// `width`/`minWidth` (`Table`'s `fixedLayout` prop, which also sets
+/// `table-layout: fixed` on the `table` element inline). Fixed layout takes a
+/// column's CSS `width` as its exact rendered size; auto layout instead treats
+/// it as a floor and grows the column to fit content. The expand column's
+/// `width: 32px` is one such floor: the expand button's padding and icon need
+/// 40px, so auto layout already renders it at 40px. Fixed layout enforces the
+/// bare 32px instead, visibly shrinking the chevron. Re-declare the column at
+/// the size auto layout already renders it so both layouts agree.
+/// See https://github.com/carbon-design-system/carbon-components-svelte/issues/3777
+/// @access private
+/// @group components
+@mixin data-table-fixed-layout {
+  .#{$prefix}--data-table--fixed-layout .#{$prefix}--table-expand { // ccs: flatten
+    width: to-rem(40px);
+  }
+}
+
+@include exports("data-table-fixed-layout") {
+  @include data-table-fixed-layout;
+}

--- a/docs/src/pages/components/DataTable.svx
+++ b/docs/src/pages/components/DataTable.svx
@@ -1739,6 +1739,46 @@ Set `expandable` to `true` to make rows expandable. Use `expandedRow` to customi
   </svelte:fragment>
 </DataTable>
 
+### Custom widths
+
+Setting `width` on a header keeps the expand column at its usual size.
+
+<DataTable expandable
+  headers="{[
+    { key: "name", value: "Name" },
+    { key: "protocol", value: "Protocol" },
+    { key: "port", value: "Port", width: "72px" },
+    { key: "rule", value: "Rule" }
+  ]}"
+  rows="{[
+    {
+      id: "a",
+      name: "Load Balancer 3",
+      protocol: "HTTP",
+      port: 3000,
+      rule: "Round robin"
+    },
+    {
+      id: "b",
+      name: "Load Balancer 1",
+      protocol: "HTTP",
+      port: 443,
+      rule: "Round robin"
+    },
+    {
+      id: "c",
+      name: "Load Balancer 2",
+      protocol: "HTTP",
+      port: 80,
+      rule: "DNS delegation"
+    },
+  ]}"
+>
+  <svelte:fragment slot="expandedRow" let:row>
+    <pre>{JSON.stringify(row, null, 2)}</pre>
+  </svelte:fragment>
+</DataTable>
+
 ### Custom icon
 
 Use the `expandIcon` slot to customize the expand/collapse icon. The slot receives expanded (whether the row is expanded), row (the row data, or undefined for the header expand-all button), and props (with aria-hidden and class to spread onto your icon).

--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -917,6 +917,7 @@
       {stickyHeader}
       {sortable}
       {useStaticWidth}
+      fixedLayout={hasCustomHeaderWidth}
       labelledBy={hasTitle ? titleId : undefined}
       describedBy={hasDescription ? descriptionId : undefined}
       tableStyle={[

--- a/src/DataTable/Table.svelte
+++ b/src/DataTable/Table.svelte
@@ -18,6 +18,11 @@
   export let stickyHeader = false;
 
   /**
+   * Set to `true` to use a fixed table layout, typically when headers specify an explicit `width`/`minWidth`.
+   */
+  export let fixedLayout = false;
+
+  /**
    * Set the style attribute on the `table` element.
    * @type {string}
    */
@@ -88,6 +93,7 @@
       class:bx--data-table--zebra={zebra}
       class:bx--data-table--static={useStaticWidth}
       class:bx--data-table--sticky-header={stickyHeader}
+      class:bx--data-table--fixed-layout={fixedLayout}
       style={tableStyle}
     >
       <slot />
@@ -107,6 +113,7 @@
       class:bx--data-table--zebra={zebra}
       class:bx--data-table--static={useStaticWidth}
       class:bx--data-table--sticky-header={stickyHeader}
+      class:bx--data-table--fixed-layout={fixedLayout}
       {...$$restProps}
       style={tableStyle}
     >

--- a/tests/DataTable/DataTable.test.ts
+++ b/tests/DataTable/DataTable.test.ts
@@ -1373,6 +1373,29 @@ describe("DataTable", () => {
     expect(protocolHeader).toHaveStyle({ "min-width": "100px" });
   });
 
+  // Regression: table-layout: fixed strictly enforces the expand column's
+  // CSS width (32px), clipping the chevron that auto layout otherwise grows
+  // to fit (40px). Pin the expand column width so it matches auto layout.
+  it("marks the table fixed-layout when a header has a custom width, so CSS can keep the expand column stable", () => {
+    const customHeaders = [
+      { key: "name", value: "Name" },
+      { key: "protocol", value: "Protocol" },
+      { key: "port", value: "Port", width: "72px" },
+      { key: "rule", value: "Rule" },
+    ] as const;
+
+    render(DataTable, {
+      props: {
+        expandable: true,
+        headers: customHeaders,
+        rows,
+      },
+    });
+
+    const table = screen.getByRole("table");
+    expect(table).toHaveClass("bx--data-table--fixed-layout");
+  });
+
   describe("column alignment", () => {
     const alignedHeaders = [
       { key: "name", value: "Name" },


### PR DESCRIPTION
Fixes #3777

`table-layout: fixed` enforces the expand column's declared 32px
width exactly. Auto layout treats that width as a floor and grows
the column to fit the expand button's padding and icon, so it
normally renders at 40px. Setting a `width`/`minWidth` on any
header switches the table to fixed layout, so the expand chevron
visibly shrinks.

`Table` gets a new `fixedLayout` prop that applies a
`bx--data-table--fixed-layout` class. SCSS pins the expand column
back to 40px for that class, so both layouts render it the same
size.

Added a "Custom widths" example under Expansion in the docs,
reproducing the issue.

---

<img width="1018" height="374" alt="Screenshot 2026-09-09 at 9 37 05 AM" src="https://github.com/user-attachments/assets/bade5680-9dea-423f-842c-4b9467303dde" />
