### PR TITLE
fix(data-table): grow toolbar for lg/xl buttons

### DIFF
--- a/css/vendor/carbon-components/scss/components/data-table/_data-table-action.scss
+++ b/css/vendor/carbon-components/scss/components/data-table/_data-table-action.scss
@@ -25,7 +25,7 @@
   .#{$prefix}--toolbar-content {
     display: flex;
     width: 100%;
-    height: $spacing-09;
+    min-height: $spacing-09; // ccs: grow for a taller (lg/xl) button instead of clipping it
     justify-content: flex-end;
     transform: translate3d(0, 0, 0);
     transition: transform $duration--fast-02 motion(standard, productive),
@@ -404,8 +404,7 @@
   // V11: remove --small
   .#{$prefix}--table-toolbar--small,
   .#{$prefix}--table-toolbar--sm {
-    height: to-rem(32px);
-    min-height: to-rem(32px);
+    min-height: to-rem(32px); // ccs: grow for a taller (lg/xl) button instead of clipping it
 
     .#{$prefix}--toolbar-search-container-expandable,
     .#{$prefix}--toolbar-search-container-persistent,
@@ -493,7 +492,7 @@
     }
 
     .#{$prefix}--toolbar-content {
-      height: to-rem(32px);
+      min-height: to-rem(32px); // ccs: grow for a taller (lg/xl) button instead of clipping it
     }
   }
 
@@ -520,8 +519,8 @@
   }
 
   // V11: remove --small selector block
-  .#{$prefix}--table-toolbar--small .#{$prefix}--btn, // ccs: resize every button kind, not only primary
-  .#{$prefix}--table-toolbar--sm .#{$prefix}--btn {
+  .#{$prefix}--table-toolbar--small .#{$prefix}--btn:not(.#{$prefix}--btn--lg, .#{$prefix}--btn--xl), // ccs: resize every button kind, not only primary; leave an explicit lg/xl size alone
+  .#{$prefix}--table-toolbar--sm .#{$prefix}--btn:not(.#{$prefix}--btn--lg, .#{$prefix}--btn--xl) {
     height: to-rem(32px);
     min-height: auto;
     padding-top: calc(0.375rem - 3px);
@@ -561,8 +560,7 @@
 // carbon-components-svelte patch (formerly css/_data-table-toolbar.scss)
 @mixin data-table-toolbar-xs {
   .#{$prefix}--table-toolbar--xs {
-    height: $spacing-06;
-    min-height: $spacing-06;
+    min-height: $spacing-06; // ccs: grow for a taller (lg/xl) button instead of clipping it
 
     .#{$prefix}--toolbar-search-container-expandable,
     .#{$prefix}--toolbar-search-container-persistent,
@@ -655,7 +653,7 @@
     }
 
     .#{$prefix}--toolbar-content {
-      height: $spacing-06;
+      min-height: $spacing-06; // ccs: grow for a taller (lg/xl) button instead of clipping it
     }
   }
 
@@ -671,8 +669,8 @@
     padding: $spacing-02 0;
   }
 
-  // ccs: resize every button kind, not only primary
-  .#{$prefix}--table-toolbar--xs .#{$prefix}--btn {
+  // ccs: resize every button kind, not only primary; leave an explicit lg/xl size alone
+  .#{$prefix}--table-toolbar--xs .#{$prefix}--btn:not(.#{$prefix}--btn--lg, .#{$prefix}--btn--xl) {
     height: $spacing-06;
     min-height: auto;
     padding-top: 0;

--- a/docs/src/pages/components/DataTable.svx
+++ b/docs/src/pages/components/DataTable.svx
@@ -719,6 +719,35 @@ Buttons of every kind resize to match the small toolbar, not only `kind="primary
   </Toolbar>
 </DataTable>
 
+### Small (large button)
+
+A `size="short"` toolbar grows to fit an explicit `size="lg"` or `size="xl"` `Button`, instead of clipping it down to the toolbar's height.
+
+<DataTable size="short" title="Load balancers" description="Your organization's active load balancers."
+  headers="{[
+    { key: "name", value: "Name" },
+    { key: "protocol", value: "Protocol" },
+    { key: "port", value: "Port" },
+    { key: "rule", value: "Rule" }
+  ]}"
+  rows="{[
+    {
+      id: "a",
+      name: "Load Balancer 3",
+      protocol: "HTTP",
+      port: 3000,
+      rule: "Round robin"
+    },
+  ]}"
+>
+  <Toolbar>
+    <ToolbarContent>
+      <Button size="lg">Large</Button>
+      <Button size="xl">Extra large</Button>
+    </ToolbarContent>
+  </Toolbar>
+</DataTable>
+
 ### Size override
 
 Set `size` on the toolbar to override the size inherited from the DataTable. Here, `size="tall"` on the table pairs with `size="sm"` on the toolbar.


### PR DESCRIPTION
A `short`/`compact` toolbar forces every button down to its own
height. A plain-size toolbar does the same, just less obviously:
`.bx--toolbar-content` sets a fixed `height`. Put a `size="lg"`
or `size="xl"` Button in any DataTable toolbar and it gets
clipped to the toolbar's height instead of rendering at its own
size.

Toolbar and toolbar-content now use `min-height` instead of a
fixed `height`, so the toolbar grows to fit whatever's inside it.
The `short`/`compact` `.bx--btn` height override also excludes
`lg`/`xl` buttons, so their own size rules apply instead of being
squashed.

Added a "Small (large button)" example under DataTable's Toolbar
docs showing a `short` toolbar growing around `lg`/`xl` buttons.

---

<img width="1020" height="430" alt="Screenshot 2026-09-09 at 10 39 26 AM" src="https://github.com/user-attachments/assets/56d6128b-b3d8-4867-86e0-304e60908096" />
