### PR TITLE
fix(dropdown): reserve field padding for the clear button

### DIFF
--- a/css/_carbon-styles.scss
+++ b/css/_carbon-styles.scss
@@ -130,6 +130,7 @@ $ccs-theme-switching: false !default;
 @import "./user-avatar-group";
 @import "./disclosure";
 @import "./list-box-wrap-options";
+@import "./dropdown";
 @import "./action-set";
 @import "./interstitial-screen";
 @import "./full-page-error";

--- a/css/_dropdown.scss
+++ b/css/_dropdown.scss
@@ -1,0 +1,20 @@
+@import "carbon-components/scss/globals/scss/vars";
+@import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
+
+/// `.bx--list-box__field`'s base padding-right reserves room for one
+/// absolutely-positioned icon (the menu chevron). `Dropdown`'s clearable
+/// selection button is a second icon of the same size, positioned to the
+/// chevron's left, so it needs the same 24px + 8px gap the chevron already
+/// gets. Without this, a long selected label's ellipsis cutoff sits under
+/// the clear button instead of stopping short of it.
+/// @access private
+/// @group components
+@mixin dropdown-clearable {
+  .#{$prefix}--list-box__field.#{$prefix}--list-box__field--clearable {
+    padding-right: to-rem(72px);
+  }
+}
+
+@include exports("dropdown-clearable") {
+  @include dropdown-clearable;
+}

--- a/docs/src/pages/components/Dropdown.svx
+++ b/docs/src/pages/components/Dropdown.svx
@@ -37,9 +37,13 @@ Omit `selectedId` to render the dropdown with no item selected. The label appear
 
 Set `clearable` to `true` to show a clear button when an item is selected. Clearing resets `selectedId` and dispatches a `clear` event. The clear button is hidden when there is no selection.
 
-<Dropdown clearable labelText="Contact" selectedId="0" label="Choose a contact method" items="{[{id: "0", text: "Slack"},
-  {id: "1", text: "Email"},
-  {id: "2", text: "Fax"}]}" />
+A long selected label truncates with an ellipsis before the clear button instead of running underneath it.
+
+<Dropdown clearable labelText="Contact" selectedId="1" label="Choose a contact method" items={[
+  { id: "0", text: "Slack" },
+  { id: "1", text: "A very long contact method name that fills the field" },
+  { id: "2", text: "Fax" },
+]} />
 
 ### Clear button text
 

--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -658,6 +658,7 @@
         type="button"
         role="combobox"
         class:bx--list-box__field={true}
+        class:bx--list-box__field--clearable={clearable && selectedId !== undefined}
         tabindex="0"
         aria-expanded={open}
         aria-disabled={readonly || undefined}

--- a/tests/Dropdown/Dropdown.test.ts
+++ b/tests/Dropdown/Dropdown.test.ts
@@ -257,6 +257,31 @@ describe("Dropdown", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("should reserve extra field padding for the clear button only when it renders", async () => {
+    const { rerender } = render(Dropdown, {
+      props: {
+        items,
+        labelText: "Contact",
+        clearable: true,
+      },
+    });
+
+    expect(screen.getByRole("combobox")).not.toHaveClass(
+      "bx--list-box__field--clearable",
+    );
+
+    await rerender({
+      items,
+      selectedId: "0",
+      labelText: "Contact",
+      clearable: true,
+    });
+
+    expect(screen.getByRole("combobox")).toHaveClass(
+      "bx--list-box__field--clearable",
+    );
+  });
+
   it("should clear the selection and dispatch clear when clicking the clear button", async () => {
     const consoleLog = vi.spyOn(console, "log");
     render(Dropdown, {


### PR DESCRIPTION
Fixes #3782

When `clearable` is set and the selected item's text is long, the
label's ellipsis cutoff runs under the clear button. The field's
padding only reserves room for the menu chevron, not the extra
icon the clear button adds.

This PR adds a `bx--list-box__field--clearable` modifier class
that widens the field's right padding when the clear button
renders. Long selected labels now truncate before the clear
button instead of overlapping it.

---

<img width="330" height="126" alt="Screenshot 2026-09-10 at 4 52 27 AM" src="https://github.com/user-attachments/assets/15aa02d7-82be-4458-8a28-1eae3692d837" />
