### PR TITLE
feat(dropdown,multi-select): support `openOnClear` and `clear()`

### DIFF
--- a/docs/src/pages/components/Dropdown.svx
+++ b/docs/src/pages/components/Dropdown.svx
@@ -53,6 +53,22 @@ Override the assistive text for the clear interaction with `clearSelectionText` 
   {id: "1", text: "Email"},
   {id: "2", text: "Fax"}]}" />
 
+### Clear selection
+
+Use `bind:this` to access the component instance and call `Dropdown.clear()` to clear the selection. Pass `focus: false` in the options to prevent re-focusing the field.
+
+<FileSource src="/framed/Dropdown/DropdownClear" />
+
+### Open on clear
+
+By default, the menu is closed after clearing the selection.
+
+Set `openOnClear` to `true` to reopen the menu after clearing the selection. This lets users immediately browse all available items without needing to click the field again.
+
+<Dropdown openOnClear clearable labelText="Contact" label="Choose a contact method" selectedId="0" items="{[{id: "0", text: "Slack"},
+  {id: "1", text: "Email"},
+  {id: "2", text: "Fax"}]}" />
+
 ### Initial selection
 
 Set `selectedId` to pre-select an item when the dropdown first renders. The trigger shows that item's label in the closed state.

--- a/docs/src/pages/components/MultiSelect.svx
+++ b/docs/src/pages/components/MultiSelect.svx
@@ -198,6 +198,24 @@ Prevent automatic alphabetical ordering by passing a no-op function to `sortItem
     sortItem="{() => {}}"
   />
 
+### Clear selection
+
+Use `bind:this` to access the component instance and call `MultiSelect.clear()` to clear the selection. Pass `focus: false` in the options to prevent re-focusing the field.
+
+<FileSource src="/framed/MultiSelect/MultiSelectClear" />
+
+### Open on clear
+
+By default, the menu stays as-is after clearing the selection (open if it was open, closed if it was closed).
+
+Set `openOnClear` to `true` to open the menu after clearing the selection via the clear button or the Delete/Backspace shortcut. This lets users immediately browse all available items without needing to click the field again.
+
+<MultiSelect openOnClear selectedIds="{["0", "1"]}" labelText="Contact" label="Select contact methods..."
+    items="{[{id: "0", text: "Slack"},
+    {id: "1", text: "Email"},
+    {id: "2", text: "Fax"}]}"
+  />
+
 ## Filterable
 
 Enable filtering by setting `filterable` to `true`. This example includes a placeholder text for the filter input.

--- a/docs/src/pages/framed/Dropdown/DropdownClear.svelte
+++ b/docs/src/pages/framed/Dropdown/DropdownClear.svelte
@@ -1,0 +1,22 @@
+<script>
+  import { Button, Dropdown } from "carbon-components-svelte";
+
+  let ref;
+</script>
+
+<Dropdown
+  clearable
+  labelText="Contact"
+  label="Choose a contact method"
+  selectedId="1"
+  bind:this={ref}
+  items={[
+    { id: "0", text: "Slack" },
+    { id: "1", text: "Email" },
+    { id: "2", text: "Fax" },
+  ]}
+/>
+<br>
+<Button on:click={() => ref.clear()}>Clear</Button>
+<Button on:click={() => ref.clear({ focus: false })}>Clear (no focus)</Button>
+<Button on:click={() => ref.clear({ open: true })}>Clear (reopen menu)</Button>

--- a/docs/src/pages/framed/MultiSelect/MultiSelectClear.svelte
+++ b/docs/src/pages/framed/MultiSelect/MultiSelectClear.svelte
@@ -1,0 +1,21 @@
+<script>
+  import { Button, MultiSelect } from "carbon-components-svelte";
+
+  let ref;
+</script>
+
+<MultiSelect
+  labelText="Contact"
+  label="Select contact methods..."
+  selectedIds={["0", "1"]}
+  bind:this={ref}
+  items={[
+    { id: "0", text: "Slack" },
+    { id: "1", text: "Email" },
+    { id: "2", text: "Fax" },
+  ]}
+/>
+<br>
+<Button on:click={() => ref.clear()}>Clear</Button>
+<Button on:click={() => ref.clear({ focus: false })}>Clear (no focus)</Button>
+<Button on:click={() => ref.clear({ open: true })}>Clear (reopen menu)</Button>

--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -124,6 +124,13 @@
   export let selectionClearedText = "Selection cleared";
 
   /**
+   * Set to `true` to reopen the dropdown menu after clearing the selection.
+   * This allows users to immediately see all available items after clearing.
+   * Only used when `clearable` is `true`.
+   */
+  export let openOnClear = false;
+
+  /**
    * Set to `true` to use the fluid variant.
    * Inherited from the parent `FluidForm` context,
    * so it does not need to be set when used inside `FluidForm`.
@@ -528,11 +535,25 @@
     statusText = text;
   }
 
-  function clearSelection() {
+  /**
+   * Clear the dropdown selection programmatically.
+   * By default, focuses the dropdown after clearing. Set `options.focus` to `false` to prevent focusing.
+   * Set `options.open` to `true` to open the dropdown menu after clearing.
+   * @type {(options?: { focus?: boolean; open?: boolean; }) => Promise<void>}
+   * @example
+   * ```svelte
+   * <Dropdown bind:this={dropdown} items={items} />
+   * <button on:click={() => dropdown.clear()}>Clear</button>
+   * ```
+   */
+  export async function clear(options = {}) {
     if (readonly || selectedId === undefined) return;
     selectedId = undefined;
     open = false;
     announceStatus(selectionClearedText);
+    await tick();
+    if (options?.open === true) open = true;
+    if (options?.focus !== false) ref?.focus();
   }
 
   /**
@@ -731,7 +752,7 @@
           // matching the click-to-clear button. Only wired when `clearable`
           // is set, since that is what makes clearing possible at all.
           event.preventDefault();
-          clearSelection();
+          clear({ open: openOnClear });
         } else if (
           open &&
           event.key.length === 1 &&
@@ -765,7 +786,7 @@
         {#if clearable && selectedId !== undefined}
           <ListBoxSelection
             on:clear
-            on:clear={clearSelection}
+            on:clear={() => clear({ open: openOnClear })}
             translateWithId={translateWithIdSelection}
             {disabled}
             {readonly}

--- a/src/ListBox/ListBoxMenuItem.svelte
+++ b/src/ListBox/ListBoxMenuItem.svelte
@@ -60,7 +60,11 @@
     if (!node) return;
     if (highlightCursor) {
       if (optionId) {
-        unregisterHighlight = highlightCursor.register(optionId, node);
+        unregisterHighlight = highlightCursor.register(
+          optionId,
+          node,
+          isActive,
+        );
       }
       return;
     }

--- a/src/ListBox/highlightCursor.d.ts
+++ b/src/ListBox/highlightCursor.d.ts
@@ -3,7 +3,7 @@ import type { Readable } from "svelte/store";
 export const HIGHLIGHT_CURSOR_KEY: "carbon:ListBoxHighlight";
 
 export function createHighlightCursor(): {
-  register: (id: string, node: HTMLElement) => () => void;
+  register: (id: string, node: HTMLElement, isActive?: boolean) => () => void;
   set: (id: string | null | undefined, options?: { scroll?: boolean }) => void;
   highlightedId: Pick<Readable<string | null>, "subscribe">;
 };

--- a/src/ListBox/highlightCursor.js
+++ b/src/ListBox/highlightCursor.js
@@ -5,7 +5,6 @@ import { scrollIntoViewWithinMenu } from "../utils/scrollIntoViewWithinMenu.js";
 export const HIGHLIGHT_CURSOR_KEY = "carbon:ListBoxHighlight";
 
 const HIGHLIGHT_CLASS = "bx--list-box__menu-item--highlighted";
-const ACTIVE_CLASS = "bx--list-box__menu-item--active";
 
 /**
  * Two-node highlight cursor for listbox options.
@@ -14,11 +13,14 @@ const ACTIVE_CLASS = "bx--list-box__menu-item--active";
  * instead of passing `highlighted` through the `{#each}` so Svelte does not
  * invalidate every `ListBoxMenuItem` (and re-run `overflowTitle`) per key.
  *
- * Selected options keep the highlight class via `ListBoxMenuItem`'s `active`
- * class directive; this cursor will not strip it from an `--active` node.
+ * Selected options keep the highlight class while `active`; this cursor
+ * tracks active ids itself instead of reading the `--active` class back off
+ * the DOM, since that class is written by `ListBoxMenuItem`'s own `class:`
+ * directive and is not guaranteed to have been patched onto the node yet by
+ * the time this cursor runs in the same update cycle.
  *
  * @returns {{
- *   register: (id: string, node: HTMLElement) => () => void;
+ *   register: (id: string, node: HTMLElement, isActive?: boolean) => () => void;
  *   set: (id: string | null | undefined, options?: { scroll?: boolean }) => void;
  *   highlightedId: { subscribe: import("svelte/store").Readable<string | null>["subscribe"] };
  * }}
@@ -26,33 +28,39 @@ const ACTIVE_CLASS = "bx--list-box__menu-item--active";
 export function createHighlightCursor() {
   /** @type {Map<string, HTMLElement>} */
   const nodes = new Map();
+  /** @type {Set<string>} */
+  const activeIds = new Set();
   /** @type {string | null} */
   let currentId = null;
   const highlightedId = writable(/** @type {string | null} */ (null));
 
   /**
    * @param {HTMLElement} node
-   * @param {boolean} on
+   * @param {boolean} isCurrent
+   * @param {boolean} isActive
    */
-  function applyClass(node, on) {
-    if (on || node.classList.contains(ACTIVE_CLASS)) {
-      node.classList.add(HIGHLIGHT_CLASS);
-      return;
-    }
-    node.classList.remove(HIGHLIGHT_CLASS);
+  function applyClass(node, isCurrent, isActive) {
+    node.classList.toggle(HIGHLIGHT_CLASS, isCurrent || isActive);
   }
 
   /**
    * @param {string} id
    * @param {HTMLElement} node
+   * @param {boolean} [isActive]
    * @returns {() => void}
    */
-  function register(id, node) {
+  function register(id, node, isActive = false) {
     if (!id) return () => {};
     nodes.set(id, node);
-    applyClass(node, currentId === id);
+    if (isActive) {
+      activeIds.add(id);
+    } else {
+      activeIds.delete(id);
+    }
+    applyClass(node, currentId === id, isActive);
     return () => {
       if (nodes.get(id) === node) nodes.delete(id);
+      activeIds.delete(id);
     };
   }
 
@@ -66,9 +74,9 @@ export function createHighlightCursor() {
 
     const prev = currentId ? nodes.get(currentId) : undefined;
     const next = nextId ? nodes.get(nextId) : undefined;
-    if (prev) applyClass(prev, false);
+    if (prev) applyClass(prev, false, activeIds.has(currentId));
     if (next) {
-      applyClass(next, true);
+      applyClass(next, true, true);
       if (scroll && !next.matches(":hover")) {
         const inner = next.querySelector(".bx--list-box__menu-item__option");
         scrollIntoViewWithinMenu(inner instanceof HTMLElement ? inner : next);

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -216,6 +216,12 @@
   export let selectionClearedText = "All items cleared";
 
   /**
+   * Set to `true` to reopen the dropdown menu after clearing the selection.
+   * This allows users to immediately see all available items after clearing.
+   */
+  export let openOnClear = false;
+
+  /**
    * Build the assistive message announced through the status live region when
    * typing in the filterable variant changes how many options match.
    * The count excludes any "select all" item.
@@ -566,16 +572,25 @@
   }
 
   /**
-   * Clear every selected item and announce it. Shared by the clear button and
-   * the Delete/Backspace shortcuts in both field variants. No-op when nothing
-   * is selected so a bare Delete press does not announce a phantom clear.
+   * Clear the multiselect selection programmatically.
+   * By default, focuses the multiselect after clearing. Set `options.focus` to `false` to prevent focusing.
+   * Set `options.open` to `true` to open the dropdown menu after clearing.
+   * @type {(options?: { focus?: boolean; open?: boolean; }) => Promise<void>}
+   * @example
+   * ```svelte
+   * <MultiSelect bind:this={multiSelect} items={items} />
+   * <button on:click={() => multiSelect.clear()}>Clear</button>
+   * ```
    */
-  function clearSelection() {
-    if (selectionCount === 0) return;
+  export async function clear(options = {}) {
+    if (readonly || selectionCount === 0) return;
     selectedIds = [];
     lastSelectedItemId = null;
     sortedItems = sortedItems.map((item) => ({ ...item, checked: false }));
     announceStatus(selectionClearedText);
+    await tick();
+    if (options?.open === true) open = true;
+    if (options?.focus !== false) (filterable ? inputRef : fieldRef)?.focus();
   }
 
   /** Filter result count last announced; null when the menu is closed so reopening announces again. */
@@ -1008,7 +1023,7 @@
             <ListBoxSelection
               {selectionCount}
               on:clear
-              on:clear={clearSelection}
+              on:clear={() => clear({ open: openOnClear })}
               translateWithId={translateWithIdSelection}
               {disabled}
               {readonly}
@@ -1074,10 +1089,10 @@
               if (readonly) event.preventDefault();
               if (!open) open = true;
             } else if (event.key === "Backspace" && value === "") {
-              clearSelection();
+              clear({ open: openOnClear });
             } else if (event.key === "Delete") {
               value = "";
-              if (!open) clearSelection();
+              if (!open) clear({ open: openOnClear });
             }
           }}
             on:input
@@ -1221,7 +1236,7 @@
             // menu but never changes the selection.
             if (readonly) return;
             event.preventDefault();
-            clearSelection();
+            clear({ open: openOnClear });
           }
         }}
           on:blur={(event) => {
@@ -1236,7 +1251,7 @@
             <ListBoxSelection
               {selectionCount}
               on:clear
-              on:clear={clearSelection}
+              on:clear={() => clear({ open: openOnClear })}
               translateWithId={translateWithIdSelection}
               {disabled}
               {readonly}

--- a/tests/Dropdown/Dropdown.test.svelte
+++ b/tests/Dropdown/Dropdown.test.svelte
@@ -27,6 +27,7 @@
   export let translateWithIdSelection: ComponentProps<Dropdown>["translateWithIdSelection"] =
     undefined;
   export let clearable: ComponentProps<Dropdown>["clearable"] = false;
+  export let openOnClear: ComponentProps<Dropdown>["openOnClear"] = false;
   export let clearSelectionText: ComponentProps<Dropdown>["clearSelectionText"] =
     undefined;
   export let selectionClearedText: ComponentProps<Dropdown>["selectionClearedText"] =
@@ -64,6 +65,7 @@
   {translateWithId}
   {translateWithIdSelection}
   {clearable}
+  {openOnClear}
   {clearSelectionText}
   {selectionClearedText}
   {id}

--- a/tests/Dropdown/Dropdown.test.ts
+++ b/tests/Dropdown/Dropdown.test.ts
@@ -16,6 +16,7 @@ import DropdownFluidSkeleton from "./Dropdown.fluidSkeleton.test.svelte";
 import DropdownFluidSlot from "./Dropdown.fluidSlot.test.svelte";
 import DropdownLabelChildren from "./Dropdown.slot.test.svelte";
 import Dropdown from "./Dropdown.test.svelte";
+import DropdownCustom from "./DropdownCustom.test.svelte";
 import DropdownDuplicateIds from "./DropdownDuplicateIds.test.svelte";
 import DropdownGenerics from "./DropdownGenerics.test.svelte";
 import DropdownIconSlots from "./DropdownIconSlots.test.svelte";
@@ -495,6 +496,103 @@ describe("Dropdown", () => {
       await waitFor(() =>
         expect(screen.getByRole("status")).toHaveTextContent("Selection reset"),
       );
+    });
+  });
+
+  describe("openOnClear", () => {
+    it("keeps the menu closed after clearing by default", async () => {
+      render(Dropdown, {
+        props: {
+          items,
+          selectedId: "0",
+          labelText: "Contact",
+          clearable: true,
+        },
+      });
+
+      const clearButton = screen.getByRole("button", {
+        name: "Clear selected item",
+      });
+      await user.click(clearButton);
+
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    });
+
+    it("reopens the menu after clicking the clear button when true", async () => {
+      render(Dropdown, {
+        props: {
+          items,
+          selectedId: "0",
+          labelText: "Contact",
+          clearable: true,
+          openOnClear: true,
+        },
+      });
+
+      const clearButton = screen.getByRole("button", {
+        name: "Clear selected item",
+      });
+      await user.click(clearButton);
+
+      expect(screen.getByRole("listbox")).toBeVisible();
+    });
+
+    it("reopens the menu after clearing with Delete when true", async () => {
+      render(Dropdown, {
+        props: {
+          items,
+          selectedId: "0",
+          labelText: "Contact",
+          clearable: true,
+          openOnClear: true,
+        },
+      });
+
+      const combobox = screen.getByRole("combobox");
+      combobox.focus();
+      await user.keyboard("{Delete}");
+
+      expect(screen.getByRole("listbox")).toBeVisible();
+    });
+  });
+
+  describe("programmatic clear()", () => {
+    it("clears the selection and focuses the field by default", async () => {
+      render(DropdownCustom, { props: { selectedId: "0" } });
+
+      const button = screen.getByRole("combobox");
+      await user.click(screen.getByText("Clear"));
+
+      expect(within(button).queryByText("Slack")).not.toBeInTheDocument();
+      expect(button).toHaveFocus();
+    });
+
+    it("does not focus the field when options.focus is false", async () => {
+      render(DropdownCustom, { props: { selectedId: "0" } });
+
+      const button = screen.getByRole("combobox");
+      await user.click(screen.getByText("Clear (no focus)"));
+
+      expect(within(button).queryByText("Slack")).not.toBeInTheDocument();
+      expect(button).not.toHaveFocus();
+    });
+
+    it("reopens the menu when options.open is true", async () => {
+      render(DropdownCustom, { props: { selectedId: "0" } });
+
+      await user.click(screen.getByText("Clear (reopen)"));
+
+      expect(screen.getByRole("listbox")).toBeVisible();
+    });
+
+    it("is a no-op when nothing is selected", async () => {
+      render(DropdownCustom);
+
+      const button = screen.getByRole("combobox");
+      await user.click(screen.getByText("Clear"));
+
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+      expect(button).not.toHaveFocus();
     });
   });
 

--- a/tests/Dropdown/DropdownCustom.test.svelte
+++ b/tests/Dropdown/DropdownCustom.test.svelte
@@ -1,0 +1,35 @@
+<svelte:options accessors />
+
+<script lang="ts">
+  import Dropdown from "carbon-components-svelte/Dropdown/Dropdown.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let dropdownRef: Dropdown | undefined = undefined;
+
+  export let items: ComponentProps<Dropdown>["items"] = [
+    { id: "0", text: "Slack" },
+    { id: "1", text: "Email" },
+    { id: "2", text: "Fax" },
+  ];
+  export let selectedId: ComponentProps<Dropdown>["selectedId"] = undefined;
+  export let clearOptions: { focus?: boolean; open?: boolean } = {};
+</script>
+
+<Dropdown
+  bind:this={dropdownRef}
+  {items}
+  {selectedId}
+  clearable
+  labelText="Contact"
+  label="Choose a contact method"
+/>
+
+<button type="button" on:click={() => dropdownRef?.clear(clearOptions)}>
+  Clear
+</button>
+<button type="button" on:click={() => dropdownRef?.clear({ focus: false })}>
+  Clear (no focus)
+</button>
+<button type="button" on:click={() => dropdownRef?.clear({ open: true })}>
+  Clear (reopen)
+</button>

--- a/tests/ListBox/highlightCursor.test.ts
+++ b/tests/ListBox/highlightCursor.test.ts
@@ -1,13 +1,11 @@
 import { createHighlightCursor } from "../../src/ListBox/highlightCursor.js";
 
 const HIGHLIGHT = "bx--list-box__menu-item--highlighted";
-const ACTIVE = "bx--list-box__menu-item--active";
 
-function option(id: string, { active = false } = {}) {
+function option(id: string) {
   const node = document.createElement("div");
   node.id = id;
   node.className = "bx--list-box__menu-item";
-  if (active) node.classList.add(ACTIVE, HIGHLIGHT);
   const inner = document.createElement("div");
   inner.className = "bx--list-box__menu-item__option";
   node.appendChild(inner);
@@ -49,17 +47,31 @@ describe("createHighlightCursor", () => {
 
   it("does not strip highlight from an active (selected) node", () => {
     const cursor = createHighlightCursor();
-    const selected = option("sel", { active: true });
+    const selected = option("sel");
     const other = option("other");
-    cursor.register("sel", selected);
+    cursor.register("sel", selected, true);
     cursor.register("other", other);
 
     cursor.set("sel", { scroll: false });
     cursor.set("other", { scroll: false });
 
     expect(selected).toHaveClass(HIGHLIGHT);
-    expect(selected).toHaveClass(ACTIVE);
     expect(other).toHaveClass(HIGHLIGHT);
+  });
+
+  it("re-registering with isActive false clears the highlight once the cursor moves on", () => {
+    const cursor = createHighlightCursor();
+    const selected = option("sel");
+    const other = option("other");
+    cursor.register("sel", selected, true);
+    cursor.register("other", other);
+    cursor.set("other", { scroll: false });
+
+    // Deselecting re-registers with `isActive: false`, mirroring
+    // `ListBoxMenuItem` re-running `bindCursor` when its `active` prop flips.
+    cursor.register("sel", selected, false);
+
+    expect(selected).not.toHaveClass(HIGHLIGHT);
   });
 
   it("applies highlight on register when set ran first", () => {

--- a/tests/MultiSelect/MultiSelect.test.svelte
+++ b/tests/MultiSelect/MultiSelect.test.svelte
@@ -23,6 +23,7 @@
   export let readonly = false;
   export let readonlyText: ComponentProps<MultiSelect>["readonlyText"] =
     undefined;
+  export let openOnClear: ComponentProps<MultiSelect>["openOnClear"] = false;
   export let clearSelectionText: ComponentProps<MultiSelect>["clearSelectionText"] =
     undefined;
   export let selectionClearedText: ComponentProps<MultiSelect>["selectionClearedText"] =
@@ -74,6 +75,7 @@
   {disabled}
   {readonly}
   {readonlyText}
+  {openOnClear}
   {clearSelectionText}
   {selectionClearedText}
   {filterResultsText}

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -18,6 +18,7 @@ import MultiSelectFluidSlot from "./MultiSelect.fluidSlot.test.svelte";
 import MultiSelectLabelSlot from "./MultiSelect.slot.test.svelte";
 import MultiSelect from "./MultiSelect.test.svelte";
 import MultiSelectBindValue from "./MultiSelectBindValue.test.svelte";
+import MultiSelectCustom from "./MultiSelectCustom.test.svelte";
 import MultiSelectDuplicateIds from "./MultiSelectDuplicateIds.test.svelte";
 import MultiSelectGenerics from "./MultiSelectGenerics.test.svelte";
 import MultiSelectInModal from "./MultiSelectInModal.test.svelte";
@@ -3808,6 +3809,107 @@ describe("MultiSelect", () => {
       await waitFor(() =>
         expect(screen.getByRole("status")).toHaveTextContent("Selection reset"),
       );
+    });
+  });
+
+  describe("openOnClear", () => {
+    it("does not open the menu after clearing by default", async () => {
+      const { container } = render(MultiSelect, {
+        props: { items, labelText: "Contact methods", selectedIds: ["0"] },
+      });
+
+      const closeIcon = container.querySelector(".bx--tag__close-icon");
+      assert(closeIcon);
+      await user.click(closeIcon);
+
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    });
+
+    it("opens the menu after clicking the clear button when true", async () => {
+      const { container } = render(MultiSelect, {
+        props: {
+          items,
+          labelText: "Contact methods",
+          selectedIds: ["0"],
+          openOnClear: true,
+        },
+      });
+
+      const closeIcon = container.querySelector(".bx--tag__close-icon");
+      assert(closeIcon);
+      await user.click(closeIcon);
+
+      expect(screen.getByRole("listbox")).toBeVisible();
+    });
+
+    it("opens the menu after clearing with Delete when true", async () => {
+      render(MultiSelect, {
+        props: {
+          items,
+          labelText: "Contact methods",
+          selectedIds: ["0"],
+          openOnClear: true,
+        },
+      });
+
+      const combobox = screen.getByRole("combobox");
+      combobox.focus();
+      await user.keyboard("{Delete}");
+
+      expect(screen.getByRole("listbox")).toBeVisible();
+    });
+  });
+
+  describe("programmatic clear()", () => {
+    it("clears the selection and focuses the field by default", async () => {
+      render(MultiSelectCustom, { props: { selectedIds: ["0", "1"] } });
+
+      const combobox = screen.getByRole("combobox");
+      await user.click(screen.getByText("Clear"));
+
+      await user.click(combobox);
+      for (const option of screen.getAllByRole("option")) {
+        expect(option).toHaveAttribute("aria-selected", "false");
+      }
+      expect(combobox).toHaveFocus();
+    });
+
+    it("does not focus the field when options.focus is false", async () => {
+      render(MultiSelectCustom, { props: { selectedIds: ["0", "1"] } });
+
+      const combobox = screen.getByRole("combobox");
+      await user.click(screen.getByText("Clear (no focus)"));
+
+      expect(combobox).not.toHaveFocus();
+    });
+
+    it("opens the menu when options.open is true", async () => {
+      render(MultiSelectCustom, { props: { selectedIds: ["0", "1"] } });
+
+      await user.click(screen.getByText("Clear (reopen)"));
+
+      expect(screen.getByRole("listbox")).toBeVisible();
+    });
+
+    it("focuses the filter input, not the field, when filterable", async () => {
+      render(MultiSelectCustom, {
+        props: { selectedIds: ["0", "1"], filterable: true },
+      });
+
+      const combobox = screen.getByRole("combobox");
+      await user.click(screen.getByText("Clear"));
+
+      expect(combobox).toHaveFocus();
+    });
+
+    it("is a no-op when nothing is selected", async () => {
+      render(MultiSelectCustom);
+
+      const combobox = screen.getByRole("combobox");
+      await user.click(screen.getByText("Clear"));
+
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+      expect(combobox).not.toHaveFocus();
     });
   });
 

--- a/tests/MultiSelect/MultiSelectCustom.test.svelte
+++ b/tests/MultiSelect/MultiSelectCustom.test.svelte
@@ -1,0 +1,36 @@
+<svelte:options accessors />
+
+<script lang="ts">
+  import MultiSelect from "carbon-components-svelte/MultiSelect/MultiSelect.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let multiSelectRef: MultiSelect | undefined = undefined;
+
+  export let items: ComponentProps<MultiSelect>["items"] = [
+    { id: "0", text: "Slack" },
+    { id: "1", text: "Email" },
+    { id: "2", text: "Fax" },
+  ];
+  export let selectedIds: ComponentProps<MultiSelect>["selectedIds"] = [];
+  export let filterable: ComponentProps<MultiSelect>["filterable"] = false;
+  export let clearOptions: { focus?: boolean; open?: boolean } = {};
+</script>
+
+<MultiSelect
+  bind:this={multiSelectRef}
+  {items}
+  {selectedIds}
+  {filterable}
+  labelText="Contact methods"
+  label="Select contact methods..."
+/>
+
+<button type="button" on:click={() => multiSelectRef?.clear(clearOptions)}>
+  Clear
+</button>
+<button type="button" on:click={() => multiSelectRef?.clear({ focus: false })}>
+  Clear (no focus)
+</button>
+<button type="button" on:click={() => multiSelectRef?.clear({ open: true })}>
+  Clear (reopen)
+</button>


### PR DESCRIPTION
Clearing a Dropdown or MultiSelect selection leaves focus
wherever the click landed, and Dropdown's menu always closes.
ComboBox already has `openOnClear` and a `clear()` method to
control both. Separately, clearing a MultiSelect selection while
the menu stayed open could leave a row's highlight stuck on
screen after its checkbox unchecked, because the shared
highlight cursor read a stale DOM class mid-update.

This PR adds `openOnClear` and a programmatic `clear()` method
to Dropdown and MultiSelect, matching ComboBox, and fixes the
stale highlight read in the shared cursor. Clearing a selection
can now refocus the field and reopen the menu on request, and a
cleared row never gets stuck looking selected.

**Notes**
- The highlight cursor now tracks active ids itself instead of
  reading `classList` off the DOM, which fixes a render-order
  race between its own class write and `ListBoxMenuItem`'s
  `class:active` directive.
- `MultiSelect.clear()` focuses `inputRef` when `filterable`,
  `fieldRef` otherwise.

---

<img width="858" height="259" alt="Screenshot 2026-09-10 at 5 27 01 PM" src="https://github.com/user-attachments/assets/67bbfb05-91dd-4d31-882b-954ffc5405b6" />
<img width="859" height="251" alt="Screenshot 2026-09-10 at 5 27 12 PM" src="https://github.com/user-attachments/assets/b9af687e-b769-43b4-9724-7b367c3011a9" />
