### PR TITLE
perf: optimize layout-forcing DOM reads in components, utils

### DIFF
--- a/src/DatePicker/DatePicker.svelte
+++ b/src/DatePicker/DatePicker.svelte
@@ -117,6 +117,7 @@
   } from "svelte";
   import { derived, writable } from "svelte/store";
   import { dismiss } from "../utils/dismiss.js";
+  import { rafThrottle } from "../utils/rafThrottle.js";
   import { uniqueId } from "../utils/uniqueId.js";
   import { createCalendar, resolveLocale } from "./createCalendar";
   import {
@@ -183,7 +184,9 @@
   let prevValueTo = valueTo;
   let lastAppliedOptions = {};
   let calendarUsesFixedPositioning = false;
+  /** @type {(ReturnType<typeof rafThrottle> & { cancel: () => void }) | null} */
   let onCalendarReposition = null;
+  const SCROLL_LISTENER_OPTIONS = { capture: true, passive: true };
   /** @type {HTMLElement | null} */
   let topLayerAncestor = null;
   // Set from onOpen/onClose. Outside-click listener attaches only while open.
@@ -282,15 +285,26 @@
 
   function attachFixedRepositionListeners() {
     if (!calendar || onCalendarReposition) return;
-    onCalendarReposition = () => positionFlatpickrCalendarFixed(calendar);
-    window.addEventListener("scroll", onCalendarReposition, true);
-    window.addEventListener("resize", onCalendarReposition);
+    // Repositioning reads the calendar's children and the input's rect, so
+    // coalesce to one pass per frame. Capture catches scroll on any ancestor;
+    // passive tells the browser the handler never blocks scrolling.
+    const reposition = rafThrottle(() => {
+      if (calendar) positionFlatpickrCalendarFixed(calendar);
+    });
+    onCalendarReposition = reposition;
+    window.addEventListener("scroll", reposition, SCROLL_LISTENER_OPTIONS);
+    window.addEventListener("resize", reposition, { passive: true });
   }
 
   function detachFixedRepositionListeners() {
     if (!onCalendarReposition) return;
-    window.removeEventListener("scroll", onCalendarReposition, true);
+    window.removeEventListener(
+      "scroll",
+      onCalendarReposition,
+      SCROLL_LISTENER_OPTIONS,
+    );
     window.removeEventListener("resize", onCalendarReposition);
+    onCalendarReposition.cancel();
     onCalendarReposition = null;
   }
 

--- a/src/OverflowMenu/OverflowMenu.svelte
+++ b/src/OverflowMenu/OverflowMenu.svelte
@@ -133,6 +133,23 @@
   let buttonWidth = undefined;
   let onMountAfterUpdate = true;
 
+  /**
+   * Everything the menu's position depends on. `afterUpdate` re-measures only
+   * when this changes; it used to re-read offset dimensions on every update
+   * while open (each arrow key, hover).
+   */
+  $: positionKey = open
+    ? `${direction}|${flipped}|${size}|${effectivePortalMenu}|${menuRef ? 1 : 0}`
+    : null;
+
+  /**
+   * Key last measured against. Read and written only in `afterUpdate`.
+   * The menu's `style` uses directives rather than a `style="..."` string so
+   * a re-render (e.g. `buttonWidth` settling) never wipes the `top`/`left`
+   * written here.
+   */
+  let measuredPositionKey = null;
+
   $: if (ctxBreadcrumbItem) {
     icon = OverflowMenuHorizontal;
   }
@@ -212,15 +229,16 @@
   };
 
   afterUpdate(() => {
-    if (open) {
+    if (open && !onMountAfterUpdate && $currentIndex < 0) {
+      menuRef?.focus({ preventScroll: true });
+    }
+
+    if (open && positionKey !== measuredPositionKey && buttonRef) {
+      measuredPositionKey = positionKey;
       const width = buttonRef.offsetWidth;
       const height = buttonRef.offsetHeight;
 
       buttonWidth = width;
-
-      if (!onMountAfterUpdate && $currentIndex < 0) {
-        menuRef?.focus({ preventScroll: true });
-      }
 
       if (!effectivePortalMenu) {
         // Menu is a button sibling; position from offsetTop/offsetLeft.
@@ -254,6 +272,7 @@
     }
 
     if (!open) {
+      measuredPositionKey = null;
       currentId.set(undefined);
       currentIndex.set(0);
     }
@@ -381,7 +400,7 @@
     class:bx--overflow-menu-options--scrollable={!!maxHeight}
     class:bx--breadcrumb-menu-options={!!ctxBreadcrumbItem}
     class={menuOptionsClass}
-    style="--overflow-menu-options-after-width: {overflowMenuOptionsAfterWidth}"
+    style:--overflow-menu-options-after-width={overflowMenuOptionsAfterWidth}
     style:max-height={maxHeightStyle}
     on:keydown={(e) => {
       if (["ArrowDown", "ArrowLeft", "ArrowRight", "ArrowUp"].includes(e.key)) {
@@ -430,7 +449,10 @@
       class:bx--overflow-menu-options--scrollable={!!maxHeight}
       class:bx--breadcrumb-menu-options={!!ctxBreadcrumbItem}
       class={menuOptionsClass}
-      style="position: relative; top: auto; left: auto; --overflow-menu-options-after-width: {overflowMenuOptionsAfterWidth}"
+      style:position="relative"
+      style:top="auto"
+      style:left="auto"
+      style:--overflow-menu-options-after-width={overflowMenuOptionsAfterWidth}
       style:max-height={maxHeightStyle}
       on:keydown={(event) => {
         if (["ArrowDown", "ArrowLeft", "ArrowRight", "ArrowUp"].includes(event.key)) {

--- a/src/ScrollGradient/ScrollGradient.svelte
+++ b/src/ScrollGradient/ScrollGradient.svelte
@@ -25,6 +25,7 @@
   import { onMount } from "svelte";
 
   let scrollRef = null;
+  let contentRef = null;
   let sentinelTop = null;
   let sentinelBottom = null;
   let sentinelLeft = null;
@@ -57,11 +58,14 @@
   onMount(() => {
     updateScrollable();
 
+    // Scrollability changes only when the viewport or the content changes
+    // size. Observing both catches slot updates, font swaps and wrapping
+    // without a subtree MutationObserver, which fired (and forced a
+    // scrollWidth/scrollHeight read) on every DOM mutation inside the
+    // content, e.g. each row update of a wrapped DataTable.
     const resizeObserver = new ResizeObserver(updateScrollable);
     resizeObserver.observe(scrollRef);
-
-    const mutationObserver = new MutationObserver(updateScrollable);
-    mutationObserver.observe(scrollRef, { childList: true, subtree: true });
+    resizeObserver.observe(contentRef);
 
     const intersectionObserver = new IntersectionObserver(
       (entries) => {
@@ -91,7 +95,6 @@
 
     return () => {
       resizeObserver.disconnect();
-      mutationObserver.disconnect();
       intersectionObserver.disconnect();
     };
   });
@@ -110,6 +113,7 @@
     on:scroll
   >
     <div
+      bind:this={contentRef}
       class:bx--scroll-gradient__content={true}
       class:bx--scroll-gradient__content--v-scrollable={yScrollable}
       class:bx--scroll-gradient__content--h-scrollable={xScrollable}

--- a/src/Tile/ExpandableTile.svelte
+++ b/src/Tile/ExpandableTile.svelte
@@ -70,10 +70,30 @@
   let measuredMaxHeight = 0;
   let measuredPadding = 0;
 
+  /**
+   * Read the tile's vertical padding. `getComputedStyle` forces a style
+   * recalc, so this runs when the tile mounts or resizes rather than in
+   * `afterUpdate`, which fired on every re-render (hover, slot content).
+   */
+  function measurePadding() {
+    if (!ref) return;
+    const style = getComputedStyle(ref);
+    measuredPadding =
+      (Number.parseInt(style.getPropertyValue("padding-top"), 10) || 0) +
+      (Number.parseInt(style.getPropertyValue("padding-bottom"), 10) || 0);
+  }
+
   onMount(() => {
-    resizeObserver = new ResizeObserver(([elem]) => {
-      measuredMaxHeight = elem.contentRect.height;
+    resizeObserver = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        if (entry.target === refAbove) {
+          measuredMaxHeight = entry.contentRect.height;
+        } else if (entry.target === ref) {
+          measurePadding();
+        }
+      }
     });
+    measurePadding();
 
     return () => {
       resizeObserver.disconnect();
@@ -83,20 +103,13 @@
   $: if (resizeObserver) {
     resizeObserver.disconnect();
     if (refAbove) resizeObserver.observe(refAbove);
+    if (ref) resizeObserver.observe(ref);
   }
 
   afterUpdate(() => {
-    if (!ref) return;
-
     if (measuredMaxHeight === 0 && refAbove) {
       measuredMaxHeight = refAbove.getBoundingClientRect().height;
     }
-
-    const style = getComputedStyle(ref);
-
-    measuredPadding =
-      (Number.parseInt(style.getPropertyValue("padding-top"), 10) || 0) +
-      (Number.parseInt(style.getPropertyValue("padding-bottom"), 10) || 0);
   });
 </script>
 

--- a/src/TreeView/TreeView.svelte
+++ b/src/TreeView/TreeView.svelte
@@ -979,14 +979,26 @@
     isInitialRender: () => !initialRenderComplete,
   });
 
-  /** @param {HTMLElement | null} root */
-  function resetNodeTabIndices(root) {
-    if (!root) return;
-    const items = root.querySelectorAll('[tabindex="0"]');
-    for (let i = 0; i < items.length; i++) {
-      const el = items[i];
-      if (el instanceof HTMLElement) el.tabIndex = -1;
+  /**
+   * Elements this component set to `tabindex="0"`. Every row renders
+   * `tabindex="-1"`, so these are the only tab stops in the tree and the
+   * roving reset can clear them directly instead of querying the whole tree
+   * on every arrow key.
+   * @type {Set<HTMLElement>}
+   */
+  const rovingTabStops = new Set();
+
+  function resetNodeTabIndices() {
+    for (const el of rovingTabStops) {
+      if (el.isConnected) el.tabIndex = -1;
     }
+    rovingTabStops.clear();
+  }
+
+  /** @param {HTMLElement} el */
+  function setRovingTabStop(el) {
+    el.tabIndex = 0;
+    rovingTabStops.add(el);
   }
 
   function getTreeItemFromTarget(target) {
@@ -1046,9 +1058,9 @@
       const candidate = items[(startIndex + offset) % items.length];
       const label = (candidate.textContent ?? "").trim().toLowerCase();
       if (label.startsWith(query)) {
-        resetNodeTabIndices(ref);
+        resetNodeTabIndices();
         if (candidate instanceof HTMLElement) {
-          candidate.tabIndex = 0;
+          setRovingTabStop(candidate);
           candidate.focus();
         }
         break;
@@ -1150,9 +1162,9 @@
     }
 
     if (nextFocusNode && nextFocusNode !== treeItem) {
-      resetNodeTabIndices(ref);
+      resetNodeTabIndices();
       if (nextFocusNode instanceof HTMLElement) {
-        nextFocusNode.tabIndex = 0;
+        setRovingTabStop(nextFocusNode);
         nextFocusNode.focus();
       }
     }
@@ -1171,7 +1183,7 @@
     );
 
     if (firstFocusableNode instanceof HTMLElement) {
-      firstFocusableNode.tabIndex = 0;
+      setRovingTabStop(firstFocusableNode);
     }
   });
 

--- a/src/utils/carousel.js
+++ b/src/utils/carousel.js
@@ -54,17 +54,26 @@ export function initCarousel(container, config = {}) {
   function measureMaxHeight() {
     if (!useMaxHeight || views.length === 0) return;
 
-    let max = 0;
+    // Write every view into a measurable state, read all heights, then
+    // restore. Interleaving write/read/write per view forced one layout per
+    // view; batching the phases forces one for the whole set.
+    const wasHidden = views.map((view) => view.hidden);
     for (const view of views) {
-      const wasHidden = view.hidden;
       view.hidden = false;
       view.style.position = "absolute";
       view.style.visibility = "hidden";
+    }
+
+    let max = 0;
+    for (const view of views) {
       max = Math.max(max, view.scrollHeight);
+    }
+
+    views.forEach((view, index) => {
       view.style.position = "";
       view.style.visibility = "";
-      view.hidden = wasHidden;
-    }
+      view.hidden = wasHidden[index];
+    });
     container.style.minBlockSize = max ? `${max}px` : "";
   }
 

--- a/src/utils/overflowTitle.d.ts
+++ b/src/utils/overflowTitle.d.ts
@@ -10,6 +10,6 @@ export interface OverflowTitleParams {
 export function overflowTitle(
   node: HTMLElement,
   params?: OverflowTitleParams,
-): { update: (params?: OverflowTitleParams) => void };
+): { update: (params?: OverflowTitleParams) => void; destroy: () => void };
 
 export default overflowTitle;

--- a/src/utils/overflowTitle.js
+++ b/src/utils/overflowTitle.js
@@ -5,31 +5,58 @@
  * `params.title` wins over auto-detection, including `""`.
  * `params.measure` checks a descendant instead of `node`.
  *
+ * Measurement is deferred to a microtask. Svelte 3/4 run actions inline while
+ * mounting each item, so measuring synchronously forces one layout per item in
+ * a list (a 99-option menu paid for 100 layouts). Deferring lets every item
+ * mount first, so the batch shares a single layout. An explicit `title` needs
+ * no measurement and is applied synchronously.
+ *
  * @param {HTMLElement} node Element that gets the `title` attribute.
  * @param {import("./overflowTitle.js").OverflowTitleParams} [params]
- * @returns {{ update: (params?: import("./overflowTitle.js").OverflowTitleParams) => void }}
+ * @returns {{ update: (params?: import("./overflowTitle.js").OverflowTitleParams) => void, destroy: () => void }}
  * @example
  * <div use:overflowTitle>{text}</div>
  * <label use:overflowTitle={{ title, measure: labelText }}>...</label>
  */
 export function overflowTitle(node, params = {}) {
-  function update(next = {}) {
-    if (next.title != null) {
-      node.setAttribute("title", next.title);
-      return;
-    }
+  /** @type {import("./overflowTitle.js").OverflowTitleParams} */
+  let latest = params;
+  let scheduled = false;
+  let destroyed = false;
 
-    const measured = next.measure ?? node;
+  function measure() {
+    scheduled = false;
+    if (destroyed || latest.title != null) return;
+
+    const measured = latest.measure ?? node;
     if (measured.offsetWidth < measured.scrollWidth) {
-      node.setAttribute("title", measured.innerText);
+      // `textContent` reads the DOM text without forcing layout, unlike
+      // `innerText`, which resolves rendered text and triggers a reflow.
+      node.setAttribute("title", measured.textContent?.trim() ?? "");
     } else {
       node.removeAttribute("title");
     }
   }
 
+  function update(next = {}) {
+    latest = next;
+    if (next.title != null) {
+      node.setAttribute("title", next.title);
+      return;
+    }
+    if (scheduled) return;
+    scheduled = true;
+    queueMicrotask(measure);
+  }
+
   update(params);
 
-  return { update };
+  return {
+    update,
+    destroy() {
+      destroyed = true;
+    },
+  };
 }
 
 export default overflowTitle;

--- a/src/utils/trapFocus.js
+++ b/src/utils/trapFocus.js
@@ -21,6 +21,16 @@ export function trapFocus({ container, event }) {
   const tabbable = /** @type {HTMLElement[]} */ (
     Array.from(container.querySelectorAll(selectorTabbable))
   ).filter((el) => {
+    // One call answers display/visibility for the element and its ancestors
+    // without materialising a computed-style object per candidate.
+    if (typeof el.checkVisibility === "function") {
+      return el.checkVisibility({
+        visibilityProperty: true,
+        // Older name of the same option (Chrome 105 to 120).
+        checkVisibilityCSS: true,
+      });
+    }
+
     // Cheap geometry check first, so the (layout/style-recalc-forcing)
     // `getComputedStyle` call below is only reached for elements not
     // already excluded by it. `offsetParent` is `null` both when the

--- a/tests/DatePicker/DatePickerInDialog.test.svelte
+++ b/tests/DatePicker/DatePickerInDialog.test.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import DatePicker from "carbon-components-svelte/DatePicker/DatePicker.svelte";
+  import DatePickerInput from "carbon-components-svelte/DatePicker/DatePickerInput.svelte";
+</script>
+
+<dialog open>
+  <DatePicker datePickerType="single" portalMenu={true}>
+    <DatePickerInput labelText="Date" placeholder="mm/dd/yyyy" />
+  </DatePicker>
+</dialog>

--- a/tests/DatePicker/DatePickerInDialog.test.ts
+++ b/tests/DatePicker/DatePickerInDialog.test.ts
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/svelte";
+import { user } from "../utils/user";
+import DatePickerInDialog from "./DatePickerInDialog.test.svelte";
+
+describe("DatePicker inside a top-layer dialog", () => {
+  it("registers a passive capture scroll listener and repositions once per frame", async () => {
+    const add = vi.spyOn(window, "addEventListener");
+    const frames: FrameRequestCallback[] = [];
+    const raf = vi
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((callback) => frames.push(callback));
+
+    render(DatePickerInDialog);
+    await user.click(screen.getByLabelText("Date"));
+    await screen.findByLabelText("calendar-container");
+
+    const scrollCall = add.mock.calls.find(([type]) => type === "scroll");
+    expect(scrollCall?.[2]).toEqual({ capture: true, passive: true });
+    // Other components register their own resize listeners; match the one
+    // sharing the calendar's reposition handler.
+    const resizeCall = add.mock.calls.find(
+      ([type, listener]) => type === "resize" && listener === scrollCall?.[1],
+    );
+    expect(resizeCall?.[2]).toEqual({ passive: true });
+
+    // Several scroll events in one frame schedule a single reposition.
+    frames.length = 0;
+    window.dispatchEvent(new Event("scroll"));
+    window.dispatchEvent(new Event("scroll"));
+    window.dispatchEvent(new Event("scroll"));
+    expect(frames).toHaveLength(1);
+
+    add.mockRestore();
+    raf.mockRestore();
+  });
+});

--- a/tests/ExpandableTile/ExpandableTile.test.ts
+++ b/tests/ExpandableTile/ExpandableTile.test.ts
@@ -213,6 +213,30 @@ describe("ExpandableTile", () => {
     await user.unhover(tile);
   });
 
+  it("does not recompute padding on every re-render", async () => {
+    const getComputedStyle = vi.spyOn(window, "getComputedStyle");
+    render(ExpandableTile);
+    // Query before taking the baseline: `getByRole` and user-event both call
+    // getComputedStyle themselves, which would pollute the count.
+    const tile = screen.getByRole("button");
+    await tick();
+    await tick();
+    const afterMount = getComputedStyle.mock.calls.length;
+    expect(afterMount).toBeGreaterThan(0);
+
+    tile.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+    await tick();
+    tile.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await tick();
+    tile.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await tick();
+    tile.dispatchEvent(new MouseEvent("mouseleave", { bubbles: true }));
+    await tick();
+
+    expect(getComputedStyle.mock.calls.length).toBe(afterMount);
+    getComputedStyle.mockRestore();
+  });
+
   it("should handle max height and padding", async () => {
     render(ExpandableTile, {
       props: {

--- a/tests/OverflowMenu/OverflowMenu.test.ts
+++ b/tests/OverflowMenu/OverflowMenu.test.ts
@@ -120,6 +120,41 @@ describe("OverflowMenu", () => {
     expect(spy).toHaveBeenCalledWith("close", { trigger: "escape-key" });
   });
 
+  it("measures the trigger when opening, not on every keypress", async () => {
+    const descriptor = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "offsetWidth",
+    );
+    assert(descriptor?.get);
+    let reads = 0;
+    Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
+      configurable: true,
+      get() {
+        reads += 1;
+        return descriptor.get?.call(this);
+      },
+    });
+
+    try {
+      render(OverflowMenu);
+      const menuButton = screen.getByRole("button");
+      await user.click(menuButton);
+      await tick();
+      const afterOpen = reads;
+      expect(afterOpen).toBeGreaterThan(0);
+
+      await user.keyboard("{ArrowDown}");
+      await user.keyboard("{ArrowDown}");
+      await user.keyboard("{ArrowUp}");
+      await tick();
+
+      expect(screen.getAllByRole("menuitem")[1]).toHaveFocus();
+      expect(reads).toBe(afterOpen);
+    } finally {
+      Object.defineProperty(HTMLElement.prototype, "offsetWidth", descriptor);
+    }
+  });
+
   it("does not infinite-loop when all items are disabled", async () => {
     render(OverflowMenuAllDisabled);
 

--- a/tests/ScrollGradient/ScrollGradient.test.ts
+++ b/tests/ScrollGradient/ScrollGradient.test.ts
@@ -89,6 +89,25 @@ function getObserverFor(scrollElement: Element) {
 }
 
 describe("ScrollGradient", () => {
+  it("observes the scroll element and its content instead of mutations", async () => {
+    const observe = vi.spyOn(ResizeObserver.prototype, "observe");
+    const MutationObserverSpy = vi.fn();
+    vi.stubGlobal("MutationObserver", MutationObserverSpy);
+
+    const { container } = render(ScrollGradient);
+    await tick();
+
+    const scrollElement = container.querySelector(
+      ".bx--scroll-gradient__scroll-element",
+    );
+    const content = container.querySelector(".bx--scroll-gradient__content");
+    const observed = observe.mock.calls.map(([element]) => element);
+    expect(observed).toContain(scrollElement);
+    expect(observed).toContain(content);
+    expect(MutationObserverSpy).not.toHaveBeenCalled();
+    observe.mockRestore();
+  });
+
   it("shows no gradients when content does not overflow", async () => {
     const { container } = render(ScrollGradient);
     await tick();

--- a/tests/TreeView/TreeView.test.ts
+++ b/tests/TreeView/TreeView.test.ts
@@ -318,6 +318,28 @@ describe.each(testCases)("$name", ({ component }) => {
     expect(nextItem).toHaveFocus();
   });
 
+  it("moves the roving tab stop without querying the whole tree", async () => {
+    render(component);
+
+    const firstItem = treeItemById(0);
+    firstItem.focus();
+    const tree = screen.getByRole("tree");
+    const querySelectorAll = vi.spyOn(Element.prototype, "querySelectorAll");
+
+    await user.keyboard("{ArrowDown}");
+    await user.keyboard("{ArrowDown}");
+
+    const tabStopQueries = querySelectorAll.mock.calls.filter(([selector]) =>
+      String(selector).includes("tabindex"),
+    );
+    querySelectorAll.mockRestore();
+    expect(tabStopQueries).toHaveLength(0);
+    const focused = document.activeElement;
+    expect(focused).not.toBe(firstItem);
+    expect(tree.querySelectorAll('[tabindex="0"]')).toHaveLength(1);
+    expect(tree.querySelector('[tabindex="0"]')).toBe(focused);
+  });
+
   it("navigates with ArrowUp key", async () => {
     render(component);
 

--- a/tests/utils/carousel.test.ts
+++ b/tests/utils/carousel.test.ts
@@ -135,4 +135,35 @@ describe("initCarousel", () => {
 
     expect(views.every((view) => !view.hidden)).toBe(true);
   });
+
+  test("useMaxHeight reads every height after all views are made measurable", () => {
+    const container = buildContainer(3);
+    const views = Array.from(container.children) as HTMLElement[];
+    const heights = [30, 80, 50];
+    // Whether every sibling was already in its measuring state at read time.
+    const allMeasurableAtRead: boolean[] = [];
+    views.forEach((view, index) => {
+      Object.defineProperty(view, "scrollHeight", {
+        configurable: true,
+        get() {
+          allMeasurableAtRead.push(
+            views.every(
+              (sibling) =>
+                !sibling.hidden && sibling.style.position === "absolute",
+            ),
+          );
+          return heights[index];
+        },
+      });
+    });
+
+    initCarousel(container, { useMaxHeight: true });
+
+    expect(container.style.minBlockSize).toBe("80px");
+    expect(allMeasurableAtRead).toEqual([true, true, true]);
+    // Restored: only the active view visible, measuring styles cleared.
+    expect(views.map((view) => view.hidden)).toEqual([false, true, true]);
+    expect(views.every((view) => view.style.position === "")).toBe(true);
+    expect(views.every((view) => view.style.visibility === "")).toBe(true);
+  });
 });

--- a/tests/utils/overflowTitle.test.ts
+++ b/tests/utils/overflowTitle.test.ts
@@ -11,19 +11,15 @@ function mockSize(node: HTMLElement, offsetWidth: number, scrollWidth: number) {
   });
 }
 
+/** Let the deferred measurement run. */
+const settle = () => Promise.resolve();
+
 describe("overflowTitle action", () => {
   let node: HTMLElement;
 
   beforeEach(() => {
     node = document.createElement("div");
     node.textContent = "A very long label";
-    // jsdom lacks innerText; stub from textContent.
-    Object.defineProperty(node, "innerText", {
-      configurable: true,
-      get() {
-        return this.textContent;
-      },
-    });
     document.body.appendChild(node);
   });
 
@@ -31,25 +27,29 @@ describe("overflowTitle action", () => {
     node.remove();
   });
 
-  test("sets title to the text content when truncated", () => {
+  test("sets title to the text content when truncated", async () => {
     mockSize(node, 50, 120);
     overflowTitle(node);
+    await settle();
     expect(node.getAttribute("title")).toBe("A very long label");
   });
 
-  test("does not set title when the text fits", () => {
+  test("does not set title when the text fits", async () => {
     mockSize(node, 120, 120);
     overflowTitle(node);
+    await settle();
     expect(node.hasAttribute("title")).toBe(false);
   });
 
-  test("removes a stale title once no longer truncated on update", () => {
+  test("removes a stale title once no longer truncated on update", async () => {
     mockSize(node, 50, 120);
     const { update } = overflowTitle(node);
+    await settle();
     expect(node.getAttribute("title")).toBe("A very long label");
 
     mockSize(node, 120, 120);
     update();
+    await settle();
     expect(node.hasAttribute("title")).toBe(false);
   });
 
@@ -65,29 +65,90 @@ describe("overflowTitle action", () => {
     expect(node.getAttribute("title")).toBe("");
   });
 
-  test("measures a descendant when `measure` is provided", () => {
+  test("measures a descendant when `measure` is provided", async () => {
     const host = document.createElement("label");
     const span = document.createElement("span");
     span.textContent = "A very long label";
-    Object.defineProperty(span, "innerText", {
-      configurable: true,
-      get() {
-        return this.textContent;
-      },
-    });
     host.appendChild(span);
     document.body.appendChild(host);
 
     mockSize(span, 50, 120);
     overflowTitle(host, { measure: span });
+    await settle();
 
     expect(host.getAttribute("title")).toBe("A very long label");
     host.remove();
   });
 
-  test("falls back to measuring the node when `measure` is null", () => {
+  test("falls back to measuring the node when `measure` is null", async () => {
     mockSize(node, 50, 120);
     expect(() => overflowTitle(node, { measure: null })).not.toThrow();
+    await settle();
     expect(node.getAttribute("title")).toBe("A very long label");
+  });
+
+  test("defers measurement so a batch of mounts reads layout once", async () => {
+    const nodes = Array.from({ length: 5 }, () => {
+      const el = document.createElement("div");
+      el.textContent = "label";
+      document.body.appendChild(el);
+      return el;
+    });
+    let reads = 0;
+    for (const el of nodes) {
+      Object.defineProperty(el, "offsetWidth", {
+        configurable: true,
+        get() {
+          reads += 1;
+          return 50;
+        },
+      });
+      Object.defineProperty(el, "scrollWidth", {
+        configurable: true,
+        value: 120,
+      });
+    }
+
+    for (const el of nodes) overflowTitle(el);
+    // Nothing is read while the batch is still mounting.
+    expect(reads).toBe(0);
+    expect(nodes.every((el) => !el.hasAttribute("title"))).toBe(true);
+
+    await settle();
+    expect(reads).toBe(5);
+    expect(nodes.every((el) => el.getAttribute("title") === "label")).toBe(
+      true,
+    );
+    for (const el of nodes) el.remove();
+  });
+
+  test("applies an explicit title synchronously without measuring", () => {
+    let reads = 0;
+    Object.defineProperty(node, "offsetWidth", {
+      configurable: true,
+      get() {
+        reads += 1;
+        return 50;
+      },
+    });
+    overflowTitle(node, { title: "Fixed" });
+    expect(node.getAttribute("title")).toBe("Fixed");
+    expect(reads).toBe(0);
+  });
+
+  test("does not measure after destroy", async () => {
+    let reads = 0;
+    Object.defineProperty(node, "offsetWidth", {
+      configurable: true,
+      get() {
+        reads += 1;
+        return 50;
+      },
+    });
+    const { destroy } = overflowTitle(node);
+    destroy();
+    await settle();
+    expect(reads).toBe(0);
+    expect(node.hasAttribute("title")).toBe(false);
   });
 });

--- a/tests/utils/trapFocus.test.ts
+++ b/tests/utils/trapFocus.test.ts
@@ -177,4 +177,32 @@ describe("trapFocus", () => {
     // Only one tabbable candidate (`visible`), so Tab wraps back to itself.
     expect(document.activeElement).toBe(visible);
   });
+
+  test("uses checkVisibility when available instead of computed styles", () => {
+    const { container, buttons } = setup(3);
+    const getComputedStyle = vi.spyOn(window, "getComputedStyle");
+    for (const [index, button] of buttons.entries()) {
+      Object.defineProperty(button, "checkVisibility", {
+        configurable: true,
+        value: vi.fn(() => index !== 1),
+      });
+    }
+    buttons[0].focus();
+    const { event } = tabEvent();
+
+    trapFocus({ container, event });
+
+    // buttons[1] reports itself hidden, so Tab skips to buttons[2].
+    expect(document.activeElement).toBe(buttons[2]);
+    expect(getComputedStyle).not.toHaveBeenCalled();
+    for (const button of buttons) {
+      expect(
+        (button as unknown as { checkVisibility: ReturnType<typeof vi.fn> })
+          .checkVisibility,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({ visibilityProperty: true }),
+      );
+    }
+    getComputedStyle.mockRestore();
+  });
 });


### PR DESCRIPTION
Audit of layout-forcing DOM reads across `src/`. Eight commits, one per
finding, each with a unit test. The largest one only shows on Svelte
3/4, where actions run inline while each item mounts, so any action
that reads layout forces one reflow per item.

## Benchmark

Forced layouts counted with Chrome DevTools `Performance.getMetrics`
(`LayoutCount`), plus patched getters on `offsetWidth` and
`getComputedStyle`, on the same fixture built with Svelte 5 and with
Svelte 4.

| Scenario                        | Metric              | Before (Svelte 4) | Before (Svelte 5) | After (both) |
| ------------------------------- | ------------------- | ----------------: | ----------------: | -----------: |
| Dropdown open, 99 options       | layouts             |               100 |                 1 |            1 |
| Dropdown open, 20 options       | layouts             |                21 |                 1 |            1 |
| Mount 100 `Checkbox`            | layouts             |               100 |                 1 |            1 |
| OverflowMenu, 5 arrow keys      | `offsetWidth` reads |                10 |                10 |            0 |
| ExpandableTile, 5 slot updates  | `getComputedStyle`  |                 5 |                 0 |            0 |

The TreeView, ScrollGradient, trapFocus, carousel and DatePicker commits
remove per-keypress tree queries, a subtree `MutationObserver`, a
computed-style read per tabbable, a layout per carousel view, and a
non-passive capture scroll handler. Those aren't in the table because
their cost scales with tree size or event rate rather than a fixed
fixture.

## Risk

Gating OverflowMenu's `afterUpdate` exposed a latent bug: the menu's
`style="..."` string was re-rendered when the trigger width settled and
wiped the imperative `top`/`left`. The old per-update repositioning had
masked it. The menu now uses `style:` directives, verified by the e2e
position test and a Svelte 4 compile check.
