### PR TITLE
chore: bump biome.json schema to 2.5.13

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.12/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.13/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",


### PR DESCRIPTION
Biome CLI is on 2.5.13 but biome.json pinned the schema to 2.5.12,
which biome ci flagged as a deserialize warning.