### PR TITLE
docs(style): reduce prose-preview spacing

### DIFF
--- a/docs/src/global.css
+++ b/docs/src/global.css
@@ -487,7 +487,7 @@ html {
 }
 
 .prose > p:has(+ .preview) {
-  margin-bottom: var(--cds-layout-04);
+  margin-bottom: var(--cds-layout-02);
 }
 
 .bx--col > p > code.bx--type-code-01,

--- a/src/DataTable/DataTableSkeleton.svelte
+++ b/src/DataTable/DataTableSkeleton.svelte
@@ -62,40 +62,42 @@
       </div>
     </section>
   {/if}
-  <!-- svelte-ignore a11y-click-events-have-key-events -->
-  <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
-  <table
-    class:bx--skeleton={true}
-    class:bx--data-table={true}
-    class:bx--data-table--compact={size === "compact"}
-    class:bx--data-table--short={size === "short"}
-    class:bx--data-table--md={size === "medium"}
-    class:bx--data-table--tall={size === "tall"}
-    class:bx--data-table--zebra={zebra}
-    on:click
-    on:mouseover
-    on:mouseenter
-    on:mouseleave
-  >
-    <thead>
-      <tr>
-        {#each cols as col (col)}
-          {#if typeof values[col] === "object" && values[col].empty === true}
-            <th></th>
-          {:else}
-            <th>{values[col] || ""}</th>
-          {/if}
-        {/each}
-      </tr>
-    </thead>
-    <tbody>
-      {#each Array.from({ length: rows }, (_, i) => i) as row (row)}
+  <div class:bx--data-table-content={true}>
+    <!-- svelte-ignore a11y-click-events-have-key-events -->
+    <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
+    <table
+      class:bx--skeleton={true}
+      class:bx--data-table={true}
+      class:bx--data-table--compact={size === "compact"}
+      class:bx--data-table--short={size === "short"}
+      class:bx--data-table--md={size === "medium"}
+      class:bx--data-table--tall={size === "tall"}
+      class:bx--data-table--zebra={zebra}
+      on:click
+      on:mouseover
+      on:mouseenter
+      on:mouseleave
+    >
+      <thead>
         <tr>
           {#each cols as col (col)}
-            <td><span></span></td>
+            {#if typeof values[col] === "object" && values[col].empty === true}
+              <th></th>
+            {:else}
+              <th>{values[col] || ""}</th>
+            {/if}
           {/each}
         </tr>
-      {/each}
-    </tbody>
-  </table>
+      </thead>
+      <tbody>
+        {#each Array.from({ length: rows }, (_, i) => i) as row (row)}
+          <tr>
+            {#each cols as col (col)}
+              <td><span></span></td>
+            {/each}
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  </div>
 </div>

--- a/tests/DataTable/DataTableSkeleton.test.ts
+++ b/tests/DataTable/DataTableSkeleton.test.ts
@@ -25,4 +25,12 @@ describe("DataTableSkeleton", () => {
 
     expect(screen.getByRole("table")).toHaveClass("bx--data-table--tall");
   });
+
+  it("wraps the table in a scrollable container", () => {
+    render(DataTableSkeleton);
+
+    expect(screen.getByRole("table").parentElement).toHaveClass(
+      "bx--data-table-content",
+    );
+  });
 });


### PR DESCRIPTION
Tightens the margin below a paragraph that precedes a live preview
block, from layout-04 down to layout-02.

Also fixes DataTableSkeleton overflowing the page on mobile: the
skeleton table wasn't wrapped in .bx--data-table-content like the
real Table.svelte, so it had no scrollable container and pushed
past the viewport instead of scrolling internally.